### PR TITLE
Revert Project Name Change

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 import sbt.Def
 import scoverage.ScoverageKeys
 
-lazy val appName: String = "advance-valuation-ruling-frontend"
+lazy val appName: String = "advance-valuation-rulings-frontend"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)


### PR DESCRIPTION
The name change is causing the build to fail and we have no 2_13 releases so I don't think SM will work either 😿 

As this cannot build, I do not believe these changes have been deployed to any environment. Frontend build 41 has these changes applied and builds successfully, so we can at least deploy that whilst we look into updating this