### PR TITLE
ARS-531 Use Auth for session identifiers

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -29,7 +29,7 @@ class Module extends AbstractModule {
     bind(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).asEagerSingleton()
 
     // For session based storage instead of cred based, change to SessionIdentifierAction
-    bind(classOf[IdentifierAction]).to(classOf[SessionIdentifierAction]).asEagerSingleton()
+    bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()
 
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone.withZone(ZoneOffset.UTC))
   }


### PR DESCRIPTION
This change makes Auth (or the auth stub) a requirement to run the service

The configuration has been set at the base level to use the stubbed instance in https://github.com/hmrc/app-config-base/pull/8094