### PR TITLE
ARS-555: Send correlation Id header to backend

### DIFF
--- a/app/connectors/BackendConnector.scala
+++ b/app/connectors/BackendConnector.scala
@@ -17,17 +17,17 @@
 package connectors
 
 import scala.concurrent.{ExecutionContext, Future}
-
 import play.api.http.Status
 import play.api.mvc.Request
 import uk.gov.hmrc.http.{HttpClient, HttpException, UpstreamErrorResponse}
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendHeaderCarrierProvider
-
 import com.google.inject.Inject
 import models.{BackendError, TraderDetailsWithCountryCode}
 import models.requests.TraderDetailsRequest
+
+import java.util.UUID
 
 class BackendConnector @Inject() (
   servicesConfig: ServicesConfig,
@@ -47,7 +47,8 @@ class BackendConnector @Inject() (
     httpClient
       .POST[TraderDetailsRequest, TraderDetailsWithCountryCode](
         s"$backendURL/trader-details",
-        traderDetailsRequest
+        body = traderDetailsRequest,
+        headers = Seq("X-Correlation-ID" -> UUID.randomUUID().toString)
       )
       .map(response => Right(response))
       .recover {


### PR DESCRIPTION
This sends the correlation Id header to the backend for tracing requests in Kibana