### PR TITLE
ARS-483: Use GET request for trader details

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -20,11 +20,12 @@ import play.api.Configuration
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import com.google.inject.{Inject, Singleton}
 
 @Singleton
-class FrontendAppConfig @Inject() (configuration: Configuration) {
+class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig: ServicesConfig) {
 
   val host: String    = configuration.get[String]("host")
   val appName: String = configuration.get[String]("appName")
@@ -80,6 +81,9 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
 
   val callbackEndpointTarget: String = loadConfig("upscan.callbackUrl")
   val maximumFileSize: Int           = configuration.get[Int]("upscan.maxFileSize")
+
+  val advanceValuationRulingsBackendURL: String =
+    s"${servicesConfig.baseUrl("advance-valuation-rulings-backend")}/advance-valuation-rulings"
 
   lazy val initiateV2Url: String =
     configuration

--- a/app/controllers/CheckRegisteredDetailsController.scala
+++ b/app/controllers/CheckRegisteredDetailsController.scala
@@ -30,8 +30,8 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import connectors.BackendConnector
 import controllers.actions._
 import forms.CheckRegisteredDetailsFormProvider
-import models.{CheckRegisteredDetails, Mode}
-import models.requests.{DataRequest, TraderDetailsRequest}
+import models.{AcknowledgementReference, CheckRegisteredDetails, EoriNumber, Mode}
+import models.requests.DataRequest
 import navigation.Navigator
 import pages.CheckRegisteredDetailsPage
 import repositories.SessionRepository
@@ -65,9 +65,9 @@ class CheckRegisteredDetailsController @Inject() (
               (details: CheckRegisteredDetails) => Ok(view(form.fill(value.value), mode, details))
             )
           case None        =>
-            val acknowledgementRef = UUID.randomUUID().toString.replaceAll("-", "")
+            val ref = UUID.randomUUID().toString.replaceAll("-", "")
             backendConnector
-              .getTraderDetails(TraderDetailsRequest(acknowledgementRef, request.eoriNumber))
+              .getTraderDetails(AcknowledgementReference(ref), EoriNumber(request.eoriNumber))
               .flatMap {
                 case Right(traderDetails) =>
                   for {

--- a/app/models/AcknowledgementReference.scala
+++ b/app/models/AcknowledgementReference.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+final case class AcknowledgementReference(value: String)

--- a/app/models/EoriNumber.scala
+++ b/app/models/EoriNumber.scala
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-package models.requests
+package models
 
-import play.api.libs.json.{Json, OFormat}
-
-final case class TraderDetailsRequest(
-  acknowledgementReference: String,
-  EORI: String
-)
-
-object TraderDetailsRequest {
-  implicit val format: OFormat[TraderDetailsRequest] = Json.format[TraderDetailsRequest]
-}
+final case class EoriNumber(value: String)

--- a/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
+++ b/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
@@ -17,7 +17,8 @@
 package viewmodels.checkAnswers
 
 import play.api.i18n.Messages
-import play.twirl.api.HtmlFormat
+import play.twirl.api.{Html, HtmlFormat}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 
 import controllers.routes
@@ -33,7 +34,7 @@ object CheckRegisteredDetailsSummary {
   ): SummaryListRow =
     SummaryListRowViewModel(
       key = "checkYourAnswers.eori.name.label",
-      value = ValueViewModel(HtmlFormat.escape("Smart case Ltd").toString),
+      value = ValueViewModel(HtmlFormat.escape(answer.name).body),
       actions = Seq(
         ActionItemViewModel(
           "site.change",
@@ -49,12 +50,16 @@ object CheckRegisteredDetailsSummary {
     SummaryListRowViewModel(
       key = "checkYourAnswers.eori.address.label",
       value = ValueViewModel(
-        HtmlFormat
-          .escape("""Somewhere
-        London
-        NW11
-        United Kingdom""")
-          .toString
+        HtmlContent(
+          Html(
+            s"${HtmlFormat.escape(answer.streetAndNumber).body}<br>" +
+              s"${HtmlFormat.escape(answer.city).body}<br>" +
+              answer.postalCode
+                .map(value => s"${HtmlFormat.escape(value).body}<br>")
+                .getOrElse("") +
+              s"${HtmlFormat.escape(answer.country).body}"
+          )
+        )
       ),
       actions = Seq(
         ActionItemViewModel(
@@ -70,7 +75,7 @@ object CheckRegisteredDetailsSummary {
   ): SummaryListRow =
     SummaryListRowViewModel(
       key = "checkYourAnswers.eori.number.label",
-      value = ValueViewModel(HtmlFormat.escape("GB123456789000").toString),
+      value = ValueViewModel(HtmlFormat.escape(answer.eori).body),
       actions = Seq(
         ActionItemViewModel(
           "site.change",

--- a/it/connectors/BackendConnectorSpec.scala
+++ b/it/connectors/BackendConnectorSpec.scala
@@ -1,0 +1,102 @@
+package connectors
+
+import play.api.http.Status
+import play.api.libs.json.Json
+
+import generators.TraderDetailsGenerator
+import models.{AcknowledgementReference, EoriNumber, TraderDetailsWithCountryCode}
+import utils.{BaseIntegrationSpec, WireMockHelper}
+
+class BackendConnectorSpec
+    extends BaseIntegrationSpec
+    with WireMockHelper
+    with TraderDetailsGenerator {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    startWireMock()
+  }
+
+  override def afterAll(): Unit = {
+    stopWireMock()
+    super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    resetWireMock()
+  }
+
+  private val connector = new BackendConnector(appConfig, httpClient)
+
+  ".getTraderDetails" - {
+    "should get trader details from backend" in {
+      forAll {
+        (
+          traderDetailsWithCountryCode: TraderDetailsWithCountryCode,
+          acknowledgementReference: AcknowledgementReference
+        ) =>
+          val eoriNumber       = EoriNumber(traderDetailsWithCountryCode.EORINo)
+          val successResponse  = traderDetailsWithCountryCode
+          val expectedResponse = Json.stringify(Json.toJson(successResponse))
+
+          stubGet(
+            traderDetailsRequestUrl(acknowledgementReference, eoriNumber),
+            Status.OK,
+            expectedResponse
+          )
+
+          val traderDetails =
+            connector.getTraderDetails(acknowledgementReference, eoriNumber).futureValue.value
+
+          traderDetails mustBe successResponse
+      }
+    }
+
+    "should return BAD_GATEWAY error for trader details backend error 5xx" in {
+      forAll(
+        arbitraryEoriNumberGen.arbitrary,
+        arbitraryAcknowledgementReferenceGen.arbitrary,
+        arbitrary5xxBackendError.arbitrary
+      ) {
+        (eoriNumber, acknowledgementReference, backendError) =>
+          val expectedResponse = Json.stringify(Json.toJson(backendError))
+
+          stubGet(
+            traderDetailsRequestUrl(acknowledgementReference, eoriNumber),
+            backendError.code,
+            expectedResponse
+          )
+
+          val traderDetails =
+            connector.getTraderDetails(acknowledgementReference, eoriNumber).futureValue.left.value
+
+          traderDetails.code mustBe Status.BAD_GATEWAY
+          traderDetails.message must include(expectedResponse)
+      }
+    }
+
+    "should return INTERNAL_SERVER_ERROR error for trader details backend error 4xx" in {
+      forAll(
+        arbitraryEoriNumberGen.arbitrary,
+        arbitraryAcknowledgementReferenceGen.arbitrary,
+        arbitrary4xxBackendError.arbitrary
+      ) {
+        (eoriNumber, acknowledgementReference, backendError) =>
+          val expectedResponse = Json.stringify(Json.toJson(backendError))
+
+          stubGet(
+            traderDetailsRequestUrl(acknowledgementReference, eoriNumber),
+            backendError.code,
+            expectedResponse
+          )
+
+          val traderDetails =
+            connector.getTraderDetails(acknowledgementReference, eoriNumber).futureValue.left.value
+
+          traderDetails.code mustBe Status.INTERNAL_SERVER_ERROR
+          traderDetails.message must include(expectedResponse)
+      }
+    }
+  }
+}

--- a/it/utils/BaseIntegrationSpec.scala
+++ b/it/utils/BaseIntegrationSpec.scala
@@ -1,0 +1,61 @@
+package utils
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+import scala.concurrent.ExecutionContext
+
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSClient
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
+
+import akka.actor.ActorSystem
+import config.FrontendAppConfig
+import models.{AcknowledgementReference, EoriNumber}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, EitherValues}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+trait BaseIntegrationSpec
+    extends AnyFreeSpec
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with EitherValues
+    with GuiceOneServerPerSuite
+    with BeforeAndAfterAll
+    with TableDrivenPropertyChecks
+    with ScalaCheckPropertyChecks
+    with BeforeAndAfterEach {
+
+  implicit val system: ActorSystem               = ActorSystem()
+  implicit lazy val headerCarrier: HeaderCarrier = HeaderCarrier()
+
+  val traderDetailsEndpoint = "/advance-valuation-rulings/trader-details"
+
+  override def fakeApplication(): Application =
+    GuiceApplicationBuilder()
+      .configure("metrics.enabled" -> false)
+      .configure("auditing.enabled" -> false)
+      .configure(
+        "microservice.services.advance-valuation-rulings-backend.port" -> WireMockHelper.wireMockPort
+      )
+      .build()
+
+  implicit lazy val ec: ExecutionContext = fakeApplication().injector.instanceOf[ExecutionContext]
+  lazy val httpClient: DefaultHttpClient = fakeApplication().injector.instanceOf[DefaultHttpClient]
+  lazy val appConfig: FrontendAppConfig  = fakeApplication().injector.instanceOf[FrontendAppConfig]
+
+  def traderDetailsRequestUrl(
+    acknowledgementReference: AcknowledgementReference,
+    eoriNumber: EoriNumber
+  ): String =
+    s"$traderDetailsEndpoint/${URLEncoder.encode(acknowledgementReference.value, StandardCharsets.UTF_8.displayName())}/${URLEncoder
+        .encode(eoriNumber.value, StandardCharsets.UTF_8.displayName())}"
+}

--- a/it/utils/WireMockHelper.scala
+++ b/it/utils/WireMockHelper.scala
@@ -1,0 +1,73 @@
+package utils
+
+import java.net.ServerSocket
+
+import scala.jdk.CollectionConverters._
+import scala.util.Using
+
+import com.github.tomakehurst.wiremock.{client, WireMockServer}
+import com.github.tomakehurst.wiremock.client.{MappingBuilder, ResponseDefinitionBuilder, WireMock}
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.github.tomakehurst.wiremock.http.{HttpHeader, HttpHeaders}
+import utils.WireMockHelper.{wireMockPort, MappingBuilderExt, ResponseDefinitionBuilderExt}
+
+trait WireMockHelper {
+  val wireMockServer = new WireMockServer(wireMockConfig.port(wireMockPort))
+
+  def startWireMock(): Unit = {
+    WireMock.configureFor(wireMockPort)
+    wireMockServer.start()
+  }
+
+  def stopWireMock(): Unit =
+    wireMockServer.stop()
+
+  def resetWireMock(): Unit =
+    wireMockServer.resetAll()
+
+  def stubGet(
+    url: String,
+    statusCode: Int,
+    responseBody: String,
+    requestHeaders: Set[(String, String)] = Set.empty,
+    responseHeaders: Set[(String, String)] = Set.empty
+  ): Unit =
+    stubFor(
+      get(urlEqualTo(url))
+        .withRequestHeaders(requestHeaders)
+        .willReturn(
+          aResponse()
+            .withStatus(statusCode)
+            .withResponseHeaders(responseHeaders)
+            .withBody(responseBody)
+        )
+    )
+}
+
+object WireMockHelper {
+
+  val wireMockPort: Int = Using(new ServerSocket(0))(_.getLocalPort)
+    .getOrElse(throw new Exception("Failed to find random free port"))
+
+  implicit class MappingBuilderExt(builder: client.MappingBuilder) {
+
+    def withRequestHeaders(headers: Set[(String, String)]): MappingBuilder =
+      headers.foldLeft(builder) {
+        (builder, header) =>
+          val (key, value) = header
+          builder.withHeader(key, equalTo(value))
+      }
+  }
+
+  implicit class ResponseDefinitionBuilderExt(builder: ResponseDefinitionBuilder) {
+
+    def withResponseHeaders(headers: Set[(String, String)]): ResponseDefinitionBuilder = {
+      val responseHeadersWithContentType = Set("Content-Type" -> "application/json; charset=utf-8")
+        .union(headers)
+        .toList
+        .map { case (key, value) => HttpHeader.httpHeader(key, value) }
+      builder.withHeaders(new HttpHeaders(responseHeadersWithContentType.asJava))
+    }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,16 +9,17 @@ object AppDependencies {
   val BootstrapFrontendPlayVersion      = "7.12.0"
   val CatsVersion                       = "2.9.0"
 
-  val ScalaTestVersion         = "3.2.10"
-  val ScalaTestPlusVersion     = "3.2.10.0"
-  val ScalaTestPlusPlayVersion = "5.1.0"
-  val MockitoScalaVersion      = "1.16.42"
-  val PegdownVersion           = "1.6.0"
-  val JsoupVersion             = "1.14.3"
-  val MockitoVersion           = "3.11.2"
-  val ScalaCheckVersion        = "1.15.4"
-  val HmrcMongoTestPlayVersion = "0.74.0"
-  val FlexmarkVersion          = "0.62.2"
+  val ScalaTestVersion          = "3.2.10"
+  val ScalaTestPlusVersion      = "3.2.10.0"
+  val ScalaTestPlusPlayVersion  = "5.1.0"
+  val MockitoScalaVersion       = "1.16.42"
+  val PegdownVersion            = "1.6.0"
+  val JsoupVersion              = "1.14.3"
+  val MockitoVersion            = "3.11.2"
+  val ScalaCheckVersion         = "1.15.4"
+  val ScalaCheckRegexGenVersion = "0.1.2"
+  val HmrcMongoTestPlayVersion  = "0.74.0"
+  val FlexmarkVersion           = "0.62.2"
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
@@ -39,6 +40,7 @@ object AppDependencies {
     "com.typesafe.play"      %% "play-test"               % PlayVersion.current,
     "org.mockito"            %% "mockito-scala"           % MockitoScalaVersion,
     "org.scalacheck"         %% "scalacheck"              % ScalaCheckVersion,
+    "wolfendale"             %% "scalacheck-gen-regexp"   % ScalaCheckRegexGenVersion,
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % HmrcMongoPlayVersion,
     "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % BootstrapFrontendPlayVersion,
     "com.vladsch.flexmark"    % "flexmark-all"            % FlexmarkVersion

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -95,7 +95,7 @@ trait Generators
   def stringsWithMaxLength(maxLength: Int): Gen[String] =
     for {
       length <- choose(1, maxLength)
-      chars  <- listOfN(length, arbitrary[Char])
+      chars  <- listOfN(length, Gen.alphaNumChar)
     } yield chars.mkString
 
   def stringsLongerThan(minLength: Int): Gen[String] = for {

--- a/test-utils/generators/TraderDetailsGenerator.scala
+++ b/test-utils/generators/TraderDetailsGenerator.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generators
+
+import play.api.http.Status
+
+import models.{AcknowledgementReference, BackendError, CDSEstablishmentAddress, EoriNumber, TraderDetailsWithCountryCode}
+import org.scalacheck.{Arbitrary, Gen}
+import wolfendale.scalacheck.regexp.RegexpGen
+
+trait TraderDetailsGenerator extends Generators {
+
+  implicit lazy val arbitraryEoriNumberGen: Arbitrary[EoriNumber] = Arbitrary(
+    RegexpGen.from("([a-zA-Z]{2})(\\d{12})").map(EoriNumber)
+  )
+
+  implicit lazy val arbitraryTraderDetailsWithCountryCode: Arbitrary[TraderDetailsWithCountryCode] =
+    Arbitrary {
+      for {
+        eoriNumber      <- arbitraryEoriNumberGen.arbitrary
+        cdsFullName     <- stringsWithMaxLength(512)
+        streetAndNumber <- stringsWithMaxLength(70)
+        city            <- stringsWithMaxLength(35)
+        country         <- stringsWithMaxLength(2)
+        postalCode      <- Gen.option(stringsWithMaxLength(9))
+      } yield TraderDetailsWithCountryCode(
+        eoriNumber.value,
+        cdsFullName,
+        CDSEstablishmentAddress(streetAndNumber, city, country, postalCode)
+      )
+    }
+
+  implicit lazy val arbitraryAcknowledgementReferenceGen: Arbitrary[AcknowledgementReference] =
+    Arbitrary(stringsWithMaxLength(32).map(AcknowledgementReference))
+
+  private val error5xx = Seq(
+    Status.INTERNAL_SERVER_ERROR,
+    Status.SERVICE_UNAVAILABLE,
+    Status.BAD_GATEWAY,
+    Status.GATEWAY_TIMEOUT
+  )
+
+  private def error4xx = Seq(
+    Status.BAD_REQUEST,
+    Status.UNAUTHORIZED,
+    Status.FORBIDDEN,
+    Status.NOT_FOUND
+  )
+
+  implicit lazy val arbitrary5xxBackendError: Arbitrary[BackendError] =
+    Arbitrary {
+      for {
+        code    <- Gen.oneOf(error5xx)
+        message <- stringsWithMaxLength(255)
+      } yield BackendError(code, message)
+    }
+
+  implicit lazy val arbitrary4xxBackendError: Arbitrary[BackendError] =
+    Arbitrary {
+      for {
+        code    <- Gen.oneOf(error4xx)
+        message <- stringsWithMaxLength(255)
+      } yield BackendError(code, message)
+    }
+}

--- a/test/controllers/CheckRegisteredDetailsControllerSpec.scala
+++ b/test/controllers/CheckRegisteredDetailsControllerSpec.scala
@@ -81,9 +81,12 @@ class CheckRegisteredDetailsControllerSpec extends SpecBase with MockitoSugar {
         )
         .build()
 
-      when(mockBackendConnector.getTraderDetails(any())(any())) thenReturn Future.successful(
-        Right(traderDetailsWithCountryCode)
-      )
+      when(
+        mockBackendConnector.getTraderDetails(any(), any())(any(), any())
+      ) thenReturn Future
+        .successful(
+          Right(traderDetailsWithCountryCode)
+        )
 
       running(application) {
         val request = FakeRequest(GET, checkRegisteredDetailsRoute)
@@ -196,7 +199,9 @@ class CheckRegisteredDetailsControllerSpec extends SpecBase with MockitoSugar {
         )
         .build()
 
-      when(mockBackendConnector.getTraderDetails(any())(any())) thenReturn Future.successful(
+      when(
+        mockBackendConnector.getTraderDetails(any(), any())(any(), any())
+      ) thenReturn Future.successful(
         Left(BackendError(code = 500, message = "some backed error"))
       )
 


### PR DESCRIPTION
This PR:
- Uses a GET request to retrieve the registered details from the backend
- Fixes the `CheckYourAnswers` page to use the registered details previously retrieved