### PR TITLE
ARS-430: Use unique ObjectId as the applicationNumber

### DIFF
--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -26,13 +26,14 @@ import play.api.libs.json._
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import models.ValuationMethod._
+import org.mongodb.scala.bson.ObjectId
 import pages._
 import queries.Modifiable
 
 final case class UserAnswers(
   id: String,
   data: JsObject = Json.obj(),
-  applicationNumber: String = UUID.randomUUID.toString.replaceAll("-", ""),
+  applicationNumber: String = new ObjectId().toHexString.toUpperCase(),
   lastUpdated: Instant = Instant.now
 ) {
 


### PR DESCRIPTION
The application number now fits within the header/banner:

<img width="430" alt="Screenshot 2023-03-10 at 19 07 32" src="https://user-images.githubusercontent.com/8526655/224703003-39dffdca-8adc-4622-be30-b9c11f1a34ea.png">
