### PR TITLE
ARS-706: Align registered details page with prototype

### DIFF
--- a/app/views/CheckRegisteredDetailsView.scala.html
+++ b/app/views/CheckRegisteredDetailsView.scala.html
@@ -46,15 +46,20 @@
         @heading(messages("checkRegisteredDetails.heading", registeredDetails.eori))
         @warning(content=Html(messages("checkRegisteredDetails.warning")))
         @paragraph(Html(messages("checkRegisteredDetails.paragraph.1")))
+        @subheading(messages("checkRegisteredDetails.subheading.1"))
+
+        @paragraph(content=Html("<strong>" + messages("checkRegisteredDetails.paragraph.2") + "</strong>"))
+        @paragraph(content=Html(registeredDetails.name))
+
+        @paragraph(content=Html("<strong>" + messages("checkRegisteredDetails.paragraph.3") + "</strong>"))
         @paragraph(content=Html(
-            registeredDetails.name + "<br>" +
             registeredDetails.streetAndNumber + "<br>" +
             registeredDetails.city + "<br>" +
             registeredDetails.postalCode.map(_ + "<br>").getOrElse("") +
             registeredDetails.country
         ))
 
-        @subheading(messages("checkRegisteredDetails.subheading"))
+        @subheading(messages("checkRegisteredDetails.subheading.2"))
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),

--- a/app/views/CheckRegisteredDetailsView.scala.html
+++ b/app/views/CheckRegisteredDetailsView.scala.html
@@ -24,6 +24,7 @@
     govukButton: GovukButton,
     caption: Caption,
     heading: Heading,
+    headingH3: headingH3,
     warning: Warning,
     paragraph: Paragraph,
     subheading: Subheading,
@@ -43,17 +44,17 @@
 
 
         @caption(messages("checkRegisteredDetails.caption"))
-        @heading(messages("checkRegisteredDetails.heading", registeredDetails.eori))
+        @heading(messages("checkRegisteredDetails.heading.1", registeredDetails.eori))
         @warning(content=Html(messages("checkRegisteredDetails.warning")))
         @paragraph(Html(messages("checkRegisteredDetails.paragraph.1")))
         @subheading(messages("checkRegisteredDetails.subheading.1"))
 
         @if(registeredDetails.name.trim != "") {
-            @paragraph(content=Html("<strong>" + messages("checkRegisteredDetails.paragraph.2") + "</strong>"))
+            @headingH3(messages("checkRegisteredDetails.heading.2"), "s")
             @paragraph(content=Html(registeredDetails.name))
         }
 
-        @paragraph(content=Html("<strong>" + messages("checkRegisteredDetails.paragraph.3") + "</strong>"))
+        @headingH3(messages("checkRegisteredDetails.heading.3"), "s")
         @paragraph(content=Html(
             registeredDetails.streetAndNumber + "<br>" +
             registeredDetails.city + "<br>" +

--- a/app/views/CheckRegisteredDetailsView.scala.html
+++ b/app/views/CheckRegisteredDetailsView.scala.html
@@ -48,8 +48,10 @@
         @paragraph(Html(messages("checkRegisteredDetails.paragraph.1")))
         @subheading(messages("checkRegisteredDetails.subheading.1"))
 
-        @paragraph(content=Html("<strong>" + messages("checkRegisteredDetails.paragraph.2") + "</strong>"))
-        @paragraph(content=Html(registeredDetails.name))
+        @if(registeredDetails.name.trim != "") {
+            @paragraph(content=Html("<strong>" + messages("checkRegisteredDetails.paragraph.2") + "</strong>"))
+            @paragraph(content=Html(registeredDetails.name))
+        }
 
         @paragraph(content=Html("<strong>" + messages("checkRegisteredDetails.paragraph.3") + "</strong>"))
         @paragraph(content=Html(

--- a/app/views/components/headingH3.scala.html
+++ b/app/views/components/headingH3.scala.html
@@ -16,6 +16,6 @@
 
 @this()
 
-@(message: String)
+@(message: String, size: String = "m")
 
-<h3 class="govuk-heading-m">@message</h3>
+<h3 class="govuk-heading-@size">@message</h3>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -218,13 +218,13 @@ accountHome.para = You have not started any applications.
 accountHome.button.text = Start new application
 
 checkRegisteredDetails.title = Check the name and address for EORI number
-checkRegisteredDetails.heading = Check the name and address for EORI number {0}
+checkRegisteredDetails.heading.1 = Check the name and address for EORI number {0}
+checkRegisteredDetails.heading.2 = Registered business name
+checkRegisteredDetails.heading.3 = Registered business address
 checkRegisteredDetails.subheading.1 = EORI registration details
 checkRegisteredDetails.subheading.2 = Are these details correct?
 checkRegisteredDetails.caption = About the applicant
 checkRegisteredDetails.paragraph.1 = You can provide your own contact details on the next page.
-checkRegisteredDetails.paragraph.2 = Registered business name
-checkRegisteredDetails.paragraph.3 = Registered business address
 checkRegisteredDetails.checkYourAnswersLabel = Check the name and address for EORI number
 checkRegisteredDetails.error.required = Select yes to confirm your EORI details
 checkRegisteredDetails.change.hidden = CheckRegisteredDetails

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -219,13 +219,16 @@ accountHome.button.text = Start new application
 
 checkRegisteredDetails.title = Check the name and address for EORI number
 checkRegisteredDetails.heading = Check the name and address for EORI number {0}
-checkRegisteredDetails.subheading = Are these details correct?
+checkRegisteredDetails.subheading.1 = EORI registration details
+checkRegisteredDetails.subheading.2 = Are these details correct?
 checkRegisteredDetails.caption = About the applicant
 checkRegisteredDetails.paragraph.1 = You can provide your own contact details on the next page.
+checkRegisteredDetails.paragraph.2 = Registered business name
+checkRegisteredDetails.paragraph.3 = Registered business address
 checkRegisteredDetails.checkYourAnswersLabel = Check the name and address for EORI number
 checkRegisteredDetails.error.required = Select yes to confirm your EORI details
 checkRegisteredDetails.change.hidden = CheckRegisteredDetails
-checkRegisteredDetails.warning = These are the details we have on record. They should be the details used to register your EORI number.
+checkRegisteredDetails.warning = These are the details we have on record. They should be the details used to register your Economic Operator Registration and Identification (EORI) number.
 
 applicationContactDetails.title = Your contact details
 applicationContactDetails.heading = Your contact details


### PR DESCRIPTION
This PR aligns the registered details page with the recent changes on the prototype. The resulting page now looks like below:

![screencapture-localhost-12600-advance-valuation-ruling-check-EORI-details-2023-03-21-15_35_00](https://user-images.githubusercontent.com/8526655/226658366-ea9ed515-25af-4512-b68f-cc2240a78824.png)
