### PR TITLE
ARS-731: Fix trader check your answers page misalignment

### DIFF
--- a/app/views/CheckYourAnswersView.scala.html
+++ b/app/views/CheckYourAnswersView.scala.html
@@ -38,12 +38,12 @@
 
     @subheading(messages("checkYourAnswers.applicant.heading"))
     
-    @govukSummaryList(applicationSummary.applicant.rows)
+    @govukSummaryList(applicationSummary.applicant.rows.withCssClass("govuk-!-margin-bottom-9"))
     
     @subheading(messages("checkYourAnswers.goods.heading"))
 
     @govukSummaryList(applicationSummary.method.rows)
-    @govukSummaryList(applicationSummary.details.rows)
+    @govukSummaryList(applicationSummary.details.rows.withCssClass("govuk-!-margin-bottom-9"))
 
     @subheading(messages("checkYourAnswers.declaration.heading"))
 


### PR DESCRIPTION
The spacing between the sections is now fixed as shown in the image:

![check-your-answers-trader-beta-alignment-fixed](https://user-images.githubusercontent.com/8526655/227607490-af5eb72c-7f0a-471e-b442-e89b1c35b8f7.png)
