### PR TITLE
ARS-740: Make eoriDetails a separate model field

### DIFF
--- a/app/connectors/BackendConnector.scala
+++ b/app/connectors/BackendConnector.scala
@@ -144,15 +144,6 @@ class BackendConnector @Inject() (
 
 object BackendConnector {
   val applicant = IndividualApplicant(
-    holder = EORIDetails(
-      eori = "eori",
-      businessName = "businessName",
-      addressLine1 = "addressLine1",
-      addressLine2 = "addressLine2",
-      addressLine3 = "addressLine3",
-      postcode = "postcode",
-      country = "country"
-    ),
     contact = ContactDetails(
       name = "name",
       email = "email@email.email",
@@ -173,8 +164,19 @@ object BackendConnector {
     confidentialInformation = Some("confidentialInformation")
   )
 
+  val eoriDetails = EORIDetails(
+    eori = "eori",
+    businessName = "businessName",
+    addressLine1 = "addressLine1",
+    addressLine2 = "addressLine2",
+    addressLine3 = "addressLine3",
+    postcode = "postcode",
+    country = "country"
+  )
+
   val applicationRequest = ApplicationRequest(
     applicationNumber = ApplicationNumber("GBAVR", 1).render,
+    eoriDetails = eoriDetails,
     applicant = applicant,
     requestedMethod = requestedMethod,
     goodsDetails = goodsDetails,

--- a/app/models/requests/Applicant.scala
+++ b/app/models/requests/Applicant.scala
@@ -18,34 +18,18 @@ package models.requests
 
 import cats.data._
 import cats.data.Validated._
-import cats.implicits._
 
 import play.api.libs.json._
 
 import models._
 import pages._
 
-case class EORIDetails(
-  eori: String,
-  businessName: String,
-  addressLine1: String,
-  addressLine2: String,
-  addressLine3: String,
-  postcode: String,
-  country: String
-)
-object EORIDetails {
-  implicit val format: OFormat[EORIDetails] = Json.format[EORIDetails]
-}
-
 sealed trait Applicant
 case class IndividualApplicant(
-  holder: EORIDetails,
   contact: ContactDetails
 ) extends Applicant
 
 case class OrganisationApplicant(
-  holder: EORIDetails,
   businessContact: CompanyContactDetails
 ) extends Applicant
 
@@ -76,36 +60,17 @@ object Applicant {
   import ApplicationRequest._
   implicit val roleFormat: OFormat[Applicant] = Json.configured(jsonConfig).format[Applicant]
 
-  def eoriHolder: Applicant => EORIDetails = (applicant: Applicant) =>
-    applicant match {
-      case IndividualApplicant(holder, _)   => holder
-      case OrganisationApplicant(holder, _) => holder
-    }
-
   def contactDetails: Applicant => Option[ContactDetails] = {
-    case IndividualApplicant(_, contact) => Some(contact)
-    case OrganisationApplicant(_, _)     => None
+    case IndividualApplicant(contact) => Some(contact)
+    case OrganisationApplicant(_)     => None
   }
 
   def businessContactDetails: Applicant => Option[CompanyContactDetails] = {
-    case IndividualApplicant(_, _)         => None
-    case OrganisationApplicant(_, contact) => Some(contact)
+    case IndividualApplicant(_)         => None
+    case OrganisationApplicant(contact) => Some(contact)
   }
 
   def apply(userAnswers: UserAnswers): ValidatedNel[Page, Applicant] = {
-    val eoriDetails = userAnswers.validatedF[CheckRegisteredDetails, EORIDetails](
-      CheckRegisteredDetailsPage,
-      (crd: CheckRegisteredDetails) =>
-        EORIDetails(
-          eori = crd.eori,
-          businessName = crd.name,
-          addressLine1 = crd.streetAndNumber,
-          addressLine2 = "",
-          addressLine3 = crd.city,
-          postcode = crd.postalCode.getOrElse(""),
-          country = crd.country
-        )
-    )
 
     val contactDetails         = userAnswers
       .validatedF[ApplicationContactDetails, ContactDetails](
@@ -121,27 +86,11 @@ object Applicant {
 
     (contactDetails, businessContactDetails) match {
       case (Valid(_), Invalid(_)) =>
-        (eoriDetails, contactDetails).mapN {
-          case (holder, contact) => IndividualApplicant(holder, contact)
-        }
+        contactDetails.map(IndividualApplicant(_))
       case (Invalid(_), Valid(_)) =>
-        (eoriDetails, businessContactDetails).mapN {
-          case (holder, contact) =>
-            OrganisationApplicant(holder, contact)
-        }
+        businessContactDetails.map(OrganisationApplicant(_))
       case _                      =>
-        eoriDetails match {
-          case Valid(_)   =>
-            Invalid(NonEmptyList.of(ApplicationContactDetailsPage, BusinessContactDetailsPage))
-          case Invalid(_) =>
-            Invalid(
-              NonEmptyList.of(
-                CheckRegisteredDetailsPage,
-                ApplicationContactDetailsPage,
-                BusinessContactDetailsPage
-              )
-            )
-        }
+        Invalid(NonEmptyList.of(ApplicationContactDetailsPage, BusinessContactDetailsPage))
     }
   }
 }

--- a/app/viewmodels/checkAnswers/CheckRegisteredDetailsForAgentsSummary.scala
+++ b/app/viewmodels/checkAnswers/CheckRegisteredDetailsForAgentsSummary.scala
@@ -98,15 +98,15 @@ object CheckRegisteredDetailsForAgentsSummary {
   def rows(
     request: ApplicationRequest
   )(implicit messages: Messages): Seq[SummaryListRow] = {
-    val eoriHolder     = Applicant.eoriHolder(request.applicant)
-    val postCode       = if (eoriHolder.postcode.isEmpty) None else Some(eoriHolder.postcode)
+    val postCode       =
+      if (request.eoriDetails.postcode.isEmpty) None else Some(request.eoriDetails.postcode)
     val contactDetails = models.CheckRegisteredDetails(
       value = true,
-      eori = eoriHolder.eori,
-      name = eoriHolder.businessName,
-      streetAndNumber = eoriHolder.addressLine1 + "\n" + eoriHolder.addressLine2,
-      city = eoriHolder.addressLine3,
-      country = eoriHolder.country,
+      eori = request.eoriDetails.eori,
+      name = request.eoriDetails.businessName,
+      streetAndNumber = request.eoriDetails.addressLine1 + "\n" + request.eoriDetails.addressLine2,
+      city = request.eoriDetails.addressLine3,
+      country = request.eoriDetails.country,
       postalCode = postCode
     )
     Seq(

--- a/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
+++ b/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
@@ -98,15 +98,15 @@ object CheckRegisteredDetailsSummary {
   def rows(
     request: ApplicationRequest
   )(implicit messages: Messages): Seq[SummaryListRow] = {
-    val eoriHolder     = Applicant.eoriHolder(request.applicant)
-    val postCode       = if (eoriHolder.postcode.isEmpty) None else Some(eoriHolder.postcode)
+    val postCode       =
+      if (request.eoriDetails.postcode.isEmpty) None else Some(request.eoriDetails.postcode)
     val contactDetails = models.CheckRegisteredDetails(
       value = true,
-      eori = eoriHolder.eori,
-      name = eoriHolder.businessName,
-      streetAndNumber = eoriHolder.addressLine1 + "\n" + eoriHolder.addressLine2,
-      city = eoriHolder.addressLine3,
-      country = eoriHolder.country,
+      eori = request.eoriDetails.eori,
+      name = request.eoriDetails.businessName,
+      streetAndNumber = request.eoriDetails.addressLine1 + "\n" + request.eoriDetails.addressLine2,
+      city = request.eoriDetails.addressLine3,
+      country = request.eoriDetails.country,
       postalCode = postCode
     )
     Seq(

--- a/test-utils/generators/ApplicationRequestGenerator.scala
+++ b/test-utils/generators/ApplicationRequestGenerator.scala
@@ -77,10 +77,7 @@ trait ApplicationRequestGenerator extends Generators {
   }
 
   implicit lazy val arbitraryIndividualApplicant: Arbitrary[IndividualApplicant] = Arbitrary {
-    for {
-      eori           <- arbitraryEoriDetails.arbitrary
-      contactDetails <- arbitraryContactDetails.arbitrary
-    } yield IndividualApplicant(eori, contactDetails)
+    arbitraryContactDetails.arbitrary.map(IndividualApplicant(_))
   }
 
   implicit lazy val arbitraryGoodsDetails: Arbitrary[GoodsDetails] = Arbitrary {
@@ -184,6 +181,7 @@ trait ApplicationRequestGenerator extends Generators {
   implicit lazy val arbitraryApplicationRequest: Arbitrary[ApplicationRequest] = Arbitrary {
     for {
       applicationNumber <- arbitraryApplicationNumber.arbitrary
+      eoriDetails       <- arbitraryEoriDetails.arbitrary
       applicant         <- arbitraryIndividualApplicant.arbitrary
       goodsDetails      <- arbitraryGoodsDetails.arbitrary
       method            <- Gen.oneOf(
@@ -198,6 +196,7 @@ trait ApplicationRequestGenerator extends Generators {
       attachments       <- Gen.listOfN(numAttachments, arbitraryUploadedDocument.arbitrary)
     } yield ApplicationRequest(
       applicationNumber.render,
+      eoriDetails,
       applicant,
       method,
       goodsDetails,

--- a/test/controllers/ViewApplicationControllerSpec.scala
+++ b/test/controllers/ViewApplicationControllerSpec.scala
@@ -84,16 +84,17 @@ class ViewApplicationControllerSpec extends SpecBase with MockitoSugar {
 object ViewApplicationControllerSpec extends Generators {
   val randomString: String = stringsWithMaxLength(8).sample.get
 
+  val eoriDetails = EORIDetails(
+    eori = randomString,
+    businessName = randomString,
+    addressLine1 = randomString,
+    addressLine2 = randomString,
+    addressLine3 = "",
+    postcode = randomString,
+    country = randomString
+  )
+
   val applicant = IndividualApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = randomString,
-      addressLine3 = "",
-      postcode = randomString,
-      country = randomString
-    ),
     contact = ContactDetails(
       name = randomString,
       email = randomString,
@@ -118,6 +119,7 @@ object ViewApplicationControllerSpec extends Generators {
   val lastUpdatedString  = "22/08/2018"
   val applicationRequest = ApplicationRequest(
     applicationNumber = ApplicationNumber("GBAVR", 1).render,
+    eoriDetails = eoriDetails,
     applicant = applicant,
     requestedMethod = requestedMethod,
     goodsDetails = goodsDetails,
@@ -133,16 +135,16 @@ object ViewApplicationControllerSpec extends Generators {
   val body =
     s"""{
     |"applicationNumber": "${applicationRequest.applicationNumber}",
+    |"eoriDetails": {
+    |  "eori": "$randomString",
+    |  "businessName": "$randomString",
+    |  "addressLine1": "$randomString",
+    |  "addressLine2": "$randomString",
+    |  "addressLine3": "",
+    |  "postcode": "$randomString",
+    |  "country": "$randomString"
+    |},
     |"applicant": {
-    |  "holder": {
-    |    "eori": "$randomString",
-    |    "businessName": "$randomString",
-    |    "addressLine1": "$randomString",
-    |    "addressLine2": "$randomString",
-    |    "addressLine3": "",
-    |    "postcode": "$randomString",
-    |    "country": "$randomString"
-    |  },
     |  "contact": {
     |    "name": "$randomString",
     |    "email": "$randomString",

--- a/test/models/requests/ApplicantSpec.scala
+++ b/test/models/requests/ApplicantSpec.scala
@@ -46,7 +46,7 @@ class ApplicantSpec
 
       val result = Applicant(userAnswers)
 
-      result shouldBe Valid(IndividualApplicant(applicant.holder, applicant.contact))
+      result shouldBe Valid(IndividualApplicant(applicant.contact))
     }
 
     "succeed for a business applicant" in {
@@ -60,7 +60,7 @@ class ApplicantSpec
       val result = Applicant(userAnswers)
 
       result shouldBe Valid(
-        OrganisationApplicant(orgApplicant.holder, orgApplicant.businessContact)
+        OrganisationApplicant(orgApplicant.businessContact)
       )
     }
 
@@ -84,13 +84,7 @@ class ApplicantSpec
       val result = Applicant(userAnswers)
 
       result shouldBe Invalid(
-        NonEmptyList(
-          CheckRegisteredDetailsPage,
-          List(
-            ApplicationContactDetailsPage,
-            BusinessContactDetailsPage
-          )
-        )
+        NonEmptyList.of(ApplicationContactDetailsPage, BusinessContactDetailsPage)
       )
     }
   }
@@ -98,6 +92,16 @@ class ApplicantSpec
 
 object ApplicantSpec extends Generators {
   val randomString: String = stringsWithMaxLength(8).sample.get
+
+  val eoriDetails = EORIDetails(
+    eori = randomString,
+    businessName = randomString,
+    addressLine1 = randomString,
+    addressLine2 = "",
+    addressLine3 = randomString,
+    postcode = "abc",
+    country = randomString
+  )
 
   val checkRegisteredDetails    = CheckRegisteredDetails(
     value = true,
@@ -124,15 +128,6 @@ object ApplicantSpec extends Generators {
     company = randomString
   )
   val applicant                 = IndividualApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = "",
-      addressLine3 = randomString,
-      postcode = "abc",
-      country = randomString
-    ),
     contact = ContactDetails(
       name = randomString,
       email = randomString,
@@ -140,15 +135,6 @@ object ApplicantSpec extends Generators {
     )
   )
   val orgApplicant              = OrganisationApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = "",
-      addressLine3 = randomString,
-      postcode = "abc",
-      country = randomString
-    ),
     businessContact = CompanyContactDetails(
       name = randomString,
       email = randomString,

--- a/test/models/requests/ApplicationRequestSpec.scala
+++ b/test/models/requests/ApplicationRequestSpec.scala
@@ -40,6 +40,7 @@ class ApplicationRequestSpec
       ApplicationRequest.format.reads(Json.parse(body)) shouldBe JsSuccess(
         ApplicationRequest(
           applicationNumber = applicationNumber,
+          eoriDetails = eoriDetails,
           applicant = applicant,
           requestedMethod = requestedMethod,
           goodsDetails,
@@ -52,6 +53,7 @@ class ApplicationRequestSpec
       ApplicationRequest.format.writes(
         ApplicationRequest(
           applicationNumber = applicationNumber,
+          eoriDetails = eoriDetails,
           applicant = applicant,
           requestedMethod = requestedMethod,
           goodsDetails = goodsDetails,
@@ -113,6 +115,7 @@ class ApplicationRequestSpec
       result shouldBe Valid(
         ApplicationRequest(
           applicationNumber = applicationNumber,
+          eoriDetails = eoriDetails,
           applicant = applicant,
           requestedMethod = MethodOne(
             Some("explainHowPartiesAreRelated"),
@@ -150,16 +153,17 @@ object ApplicationRequestSpec extends Generators {
 
   val emptyUserAnswers: UserAnswers = UserAnswers("a", applicationNumber)
 
+  val eoriDetails = EORIDetails(
+    eori = randomString,
+    businessName = randomString,
+    addressLine1 = randomString,
+    addressLine2 = "",
+    addressLine3 = randomString,
+    postcode = randomString,
+    country = randomString
+  )
+
   val applicant = IndividualApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = "",
-      addressLine3 = randomString,
-      postcode = randomString,
-      country = randomString
-    ),
     contact = ContactDetails(
       name = randomString,
       email = randomString,
@@ -191,16 +195,16 @@ object ApplicationRequestSpec extends Generators {
   val body =
     s"""{
     |"applicationNumber": "$applicationNumber",
+    |"eoriDetails": {
+    |  "eori": "$randomString",
+    |  "businessName": "$randomString",
+    |  "addressLine1": "$randomString",
+    |  "addressLine2": "",
+    |  "addressLine3": "$randomString",
+    |  "postcode": "$randomString",
+    |  "country": "$randomString"
+    |},
     |"applicant": {
-    |  "holder": {
-    |    "eori": "$randomString",
-    |    "businessName": "$randomString",
-    |    "addressLine1": "$randomString",
-    |    "addressLine2": "",
-    |    "addressLine3": "$randomString",
-    |    "postcode": "$randomString",
-    |    "country": "$randomString"
-    |  },
     |  "contact": {
     |    "name": "$randomString",
     |    "email": "$randomString",

--- a/test/models/requests/GoodsDetailsSpec.scala
+++ b/test/models/requests/GoodsDetailsSpec.scala
@@ -89,6 +89,16 @@ object GoodsDetailsSpec extends Generators {
 
   val emptyUserAnswers: UserAnswers = UserAnswers("a", applicationNumber)
 
+  val eoriDetails = EORIDetails(
+    eori = randomString,
+    businessName = randomString,
+    addressLine1 = randomString,
+    addressLine2 = "",
+    addressLine3 = randomString,
+    postcode = randomString,
+    country = randomString
+  )
+
   val applicationContactDetails = ApplicationContactDetails(
     name = randomString,
     email = randomString,
@@ -101,15 +111,6 @@ object GoodsDetailsSpec extends Generators {
     company = randomString
   )
   val applicant                 = IndividualApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = "",
-      addressLine3 = randomString,
-      postcode = randomString,
-      country = randomString
-    ),
     contact = ContactDetails(
       name = randomString,
       email = randomString,
@@ -117,15 +118,6 @@ object GoodsDetailsSpec extends Generators {
     )
   )
   val orgApplicant              = OrganisationApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = "",
-      addressLine3 = randomString,
-      postcode = randomString,
-      country = randomString
-    ),
     businessContact = CompanyContactDetails(
       name = randomString,
       email = randomString,

--- a/test/models/requests/RequestedMethodSpec.scala
+++ b/test/models/requests/RequestedMethodSpec.scala
@@ -588,15 +588,6 @@ object RequestedMethodSpec extends Generators {
     company = randomString
   )
   val applicant                 = IndividualApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = "",
-      addressLine3 = randomString,
-      postcode = randomString,
-      country = randomString
-    ),
     contact = ContactDetails(
       name = randomString,
       email = randomString,
@@ -604,15 +595,6 @@ object RequestedMethodSpec extends Generators {
     )
   )
   val orgApplicant              = OrganisationApplicant(
-    holder = EORIDetails(
-      eori = randomString,
-      businessName = randomString,
-      addressLine1 = randomString,
-      addressLine2 = "",
-      addressLine3 = randomString,
-      postcode = randomString,
-      country = randomString
-    ),
     businessContact = CompanyContactDetails(
       name = randomString,
       email = randomString,


### PR DESCRIPTION
This PR extracts the `eoriDetails` from the applicant(s) into its own field in the application model:

```scala
case class ApplicationRequest(
  applicationNumber: String,
  eoriDetails: EORIDetails,
  applicant: Applicant,
  requestedMethod: RequestedMethod,
  goodsDetails: GoodsDetails,
  attachments: Seq[Attachment]
)
```