### PR TITLE
ARS-762: Fix uploaded files alignment in CYA page

### DIFF
--- a/app/viewmodels/checkAnswers/DoYouWantToUploadDocumentsSummary.scala
+++ b/app/viewmodels/checkAnswers/DoYouWantToUploadDocumentsSummary.scala
@@ -19,6 +19,8 @@ package viewmodels.checkAnswers
 import cats.syntax.all._
 
 import play.api.i18n.Messages
+import play.twirl.api.{Html, HtmlFormat}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 
 import controllers.routes
@@ -58,14 +60,20 @@ object DoYouWantToUploadDocumentsSummary {
 
 object UploadedDocumentsSummary {
 
-  private def makeRow(answer: Seq[String])(implicit messages: Messages) =
-    if (answer.isEmpty) {
+  private def makeRow(fileNames: Seq[String])(implicit messages: Messages) =
+    if (fileNames.isEmpty) {
       None
     } else {
       Some(
         SummaryListRowViewModel(
           key = "uploadSupportingDocuments.checkYourAnswersLabel",
-          value = ValueViewModel(answer.mkString(", ")),
+          value = ValueViewModel(
+            HtmlContent(
+              Html(
+                fileNames.map(fileName => Html(s"${HtmlFormat.escape(fileName).body}<br>")).mkString
+              )
+            )
+          ),
           actions = Seq(
             ActionItemViewModel(
               "site.change",


### PR DESCRIPTION
This PR fixes the alignment of the uploaded files in the check-your-answers page.

<img width="400" alt="Screenshot 2023-03-31 at 12 19 07" src="https://user-images.githubusercontent.com/8526655/229111929-02de347c-7bb9-4973-90b3-ffdd847b91c3.png">
