### PR TITLE
ARS-784: Hide trader details when consentToDisclosureOfPersonalData is false

### DIFF
--- a/app/models/CheckRegisteredDetails.scala
+++ b/app/models/CheckRegisteredDetails.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.{Json, OFormat}
 case class CheckRegisteredDetails(
   value: Boolean,
   eori: String,
+  consentToDisclosureOfPersonalData: Boolean,
   name: String,
   streetAndNumber: String,
   city: String,

--- a/app/models/TraderDetailsWithCountryCode.scala
+++ b/app/models/TraderDetailsWithCountryCode.scala
@@ -20,6 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 final case class TraderDetailsWithCountryCode(
   EORINo: String,
+  consentToDisclosureOfPersonalData: Boolean,
   CDSFullName: String,
   CDSEstablishmentAddress: CDSEstablishmentAddress,
   contactInformation: Option[ContactInformation]
@@ -28,6 +29,7 @@ final case class TraderDetailsWithCountryCode(
     CheckRegisteredDetails(
       value = false,
       eori = EORINo,
+      consentToDisclosureOfPersonalData = consentToDisclosureOfPersonalData,
       name = CDSFullName,
       streetAndNumber = CDSEstablishmentAddress.streetAndNumber,
       city = CDSEstablishmentAddress.city,

--- a/app/models/requests/ApplicationRequest.scala
+++ b/app/models/requests/ApplicationRequest.scala
@@ -70,6 +70,7 @@ object GoodsDetails {
 
 final case class TraderDetail(
   eori: String,
+  consentToDisclosureOfPersonalData: Boolean,
   businessName: String,
   addressLine1: String,
   addressLine2: Option[String],
@@ -88,6 +89,7 @@ object TraderDetail {
       (crd: CheckRegisteredDetails) =>
         TraderDetail(
           eori = crd.eori,
+          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
           businessName = crd.name,
           addressLine1 = crd.streetAndNumber,
           addressLine2 = Some(crd.city),
@@ -105,6 +107,7 @@ object TraderDetail {
       (crd) =>
         TraderDetail(
           eori = crd.eori,
+          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
           businessName = crd.name,
           addressLine1 = crd.streetAndNumber,
           addressLine2 = Some(crd.city),

--- a/app/viewmodels/checkAnswers/CheckRegisteredDetailsForAgentsSummary.scala
+++ b/app/viewmodels/checkAnswers/CheckRegisteredDetailsForAgentsSummary.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 
 import controllers.routes
 import models.{CheckMode, CheckRegisteredDetails, UserAnswers}
-import models.requests._
 import pages.CheckRegisteredDetailsPage
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
@@ -90,30 +89,14 @@ object CheckRegisteredDetailsForAgentsSummary {
     for {
       contactDetails <- userAnswer.get(CheckRegisteredDetailsPage)
       number          = registeredNumberRow(contactDetails)
-      name            = registeredNameRow(contactDetails)
-      address         = registeredAddressRow(contactDetails)
-      result          = Seq(number, name, address)
-    } yield result
-
-  def rows(
-    request: ApplicationRequest
-  )(implicit messages: Messages): Seq[SummaryListRow] = {
-    val postCode       =
-      if (request.trader.postcode.isEmpty) None else Some(request.trader.postcode)
-    val contactDetails = models.CheckRegisteredDetails(
-      value = true,
-      eori = request.trader.eori,
-      name = request.trader.businessName,
-      streetAndNumber = request.trader.addressLine1 + "\n" + request.trader.addressLine2,
-      city = request.trader.addressLine2.getOrElse(""),
-      country = request.trader.countryCode,
-      postalCode = postCode,
-      phoneNumber = request.trader.phoneNumber
-    )
-    Seq(
-      registeredNumberRow(contactDetails),
-      registeredNameRow(contactDetails),
-      registeredAddressRow(contactDetails)
-    )
-  }
+    } yield {
+      val personalDetails = if (contactDetails.consentToDisclosureOfPersonalData) {
+        val name    = registeredNameRow(contactDetails)
+        val address = registeredAddressRow(contactDetails)
+        Seq(name, address)
+      } else {
+        Nil
+      }
+      number +: personalDetails
+    }
 }

--- a/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
+++ b/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
@@ -90,10 +90,7 @@ object CheckRegisteredDetailsSummary {
     for {
       contactDetails <- userAnswer.get(CheckRegisteredDetailsPage)
       number          = registeredNumberRow(contactDetails)
-      name            = registeredNameRow(contactDetails)
-      address         = registeredAddressRow(contactDetails)
-      result          = Seq(number, name, address)
-    } yield result
+    } yield number +: getPersonalDetails(contactDetails)
 
   def rows(
     application: Application
@@ -109,12 +106,21 @@ object CheckRegisteredDetailsSummary {
       city = application.trader.addressLine2.getOrElse(""),
       country = application.trader.countryCode,
       postalCode = postCode,
-      phoneNumber = application.trader.phoneNumber
+      phoneNumber = application.trader.phoneNumber,
+      consentToDisclosureOfPersonalData = application.trader.consentToDisclosureOfPersonalData
     )
-    Seq(
-      registeredNumberRow(contactDetails),
-      registeredNameRow(contactDetails),
-      registeredAddressRow(contactDetails)
-    )
+
+    registeredNumberRow(contactDetails) +: getPersonalDetails(contactDetails)
   }
+
+  private def getPersonalDetails(
+    registeredDetails: CheckRegisteredDetails
+  )(implicit messages: Messages) =
+    if (registeredDetails.consentToDisclosureOfPersonalData) {
+      val name    = registeredNameRow(registeredDetails)
+      val address = registeredAddressRow(registeredDetails)
+      Seq(name, address)
+    } else {
+      Nil
+    }
 }

--- a/app/viewmodels/checkAnswers/summary/ApplicantSummary.scala
+++ b/app/viewmodels/checkAnswers/summary/ApplicantSummary.scala
@@ -22,7 +22,7 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 
 import models.UserAnswers
-import models.requests.{Application, ApplicationRequest}
+import models.requests.Application
 import viewmodels.checkAnswers._
 import viewmodels.govuk.summarylist._
 

--- a/app/views/CheckRegisteredDetailsView.scala.html
+++ b/app/views/CheckRegisteredDetailsView.scala.html
@@ -44,23 +44,32 @@
 
 
         @caption(messages("checkRegisteredDetails.caption"))
-        @heading(messages("checkRegisteredDetails.heading.1", registeredDetails.eori))
-        @warning(content=Html(messages("checkRegisteredDetails.warning")))
-        @paragraph(Html(messages("checkRegisteredDetails.paragraph.1")))
-        @subheading(messages("checkRegisteredDetails.subheading.1"))
 
-        @if(registeredDetails.name.trim != "") {
-            @headingH3(messages("checkRegisteredDetails.heading.2"), "s")
-            @paragraph(content=Html(registeredDetails.name))
+        @if(registeredDetails.consentToDisclosureOfPersonalData) {
+            @heading(messages("checkRegisteredDetails.heading.1", registeredDetails.eori))
+        } else {
+            @heading(messages("checkRegisteredDetails.heading.4", registeredDetails.eori))
         }
 
-        @headingH3(messages("checkRegisteredDetails.heading.3"), "s")
-        @paragraph(content=Html(
-            registeredDetails.streetAndNumber + "<br>" +
-            registeredDetails.city + "<br>" +
-            registeredDetails.postalCode.map(_ + "<br>").getOrElse("") +
-            registeredDetails.country
-        ))
+        @warning(content=Html(messages("checkRegisteredDetails.warning")))
+        @paragraph(Html(messages("checkRegisteredDetails.paragraph.1")))
+
+        @if(registeredDetails.consentToDisclosureOfPersonalData) {
+            @subheading(messages("checkRegisteredDetails.subheading.1"))
+
+            @if(registeredDetails.name.trim != "") {
+                @headingH3(messages("checkRegisteredDetails.heading.2"), "s")
+                @paragraph(content=Html(registeredDetails.name))
+            }
+
+            @headingH3(messages("checkRegisteredDetails.heading.3"), "s")
+            @paragraph(content=Html(
+                registeredDetails.streetAndNumber + "<br>" +
+                registeredDetails.city + "<br>" +
+                registeredDetails.postalCode.map(_ + "<br>").getOrElse("") +
+                registeredDetails.country
+            ))
+        }
 
         @subheading(messages("checkRegisteredDetails.subheading.2"))
         @govukRadios(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -246,6 +246,7 @@ checkRegisteredDetails.title = Check the name and address for EORI number
 checkRegisteredDetails.heading.1 = Check the name and address for EORI number {0}
 checkRegisteredDetails.heading.2 = Registered business name
 checkRegisteredDetails.heading.3 = Registered business address
+checkRegisteredDetails.heading.4 = Check the EORI number {0}
 checkRegisteredDetails.subheading.1 = EORI registration details
 checkRegisteredDetails.subheading.2 = Are these details correct?
 checkRegisteredDetails.caption = About the applicant

--- a/it/connectors/BackendConnectorSpec.scala
+++ b/it/connectors/BackendConnectorSpec.scala
@@ -119,7 +119,7 @@ class BackendConnectorSpec
     val response           = ApplicationSubmissionResponse(applicationId)
     val applicationRequest = ApplicationRequest(
       draftId = DraftId(0),
-      trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None),
+      trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None),
       agent = None,
       contact = ContactDetails("name", "email", None),
       requestedMethod = MethodOne(None, None, None),

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,38 +21,39 @@ object AppDependencies {
   val HmrcMongoTestPlayVersion  = "0.74.0"
   val FlexmarkVersion           = "0.62.2"
   val EnumeratumVersion         = "1.6.3"
+  val QuicklensVersion          = "1.9.1"
   val ObjectStoreVersion        = "1.0.0"
   val InternalAuthVersion       = "1.2.0"
   val LibPhoneNumberVersion     = "8.12.47"
 
-
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"                %% "play-frontend-hmrc"            % PlayFrontendHmrcVersion,
-    "uk.gov.hmrc"                %% "play-conditional-form-mapping" % PlayConditionalFormMappingVersion,
-    "uk.gov.hmrc"                %% "bootstrap-frontend-play-28"    % BootstrapFrontendPlayVersion,
-    "uk.gov.hmrc"                %% "internal-auth-client-play-28"  % InternalAuthVersion,
-    "uk.gov.hmrc.objectstore"    %% "object-store-client-play-28"   % ObjectStoreVersion,
-    "uk.gov.hmrc.mongo"          %% "hmrc-mongo-play-28"            % HmrcMongoPlayVersion,
-    "org.typelevel"              %% "cats-core"                     % CatsVersion,
-    "com.beachape"               %% "enumeratum-play-json"          % EnumeratumVersion,
-    "com.googlecode.libphonenumber" % "libphonenumber"             % LibPhoneNumberVersion
+    "uk.gov.hmrc"                  %% "play-frontend-hmrc"            % PlayFrontendHmrcVersion,
+    "uk.gov.hmrc"                  %% "play-conditional-form-mapping" % PlayConditionalFormMappingVersion,
+    "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28"    % BootstrapFrontendPlayVersion,
+    "uk.gov.hmrc"                  %% "internal-auth-client-play-28"  % InternalAuthVersion,
+    "uk.gov.hmrc.objectstore"      %% "object-store-client-play-28"   % ObjectStoreVersion,
+    "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-28"            % HmrcMongoPlayVersion,
+    "org.typelevel"                %% "cats-core"                     % CatsVersion,
+    "com.beachape"                 %% "enumeratum-play-json"          % EnumeratumVersion,
+    "com.googlecode.libphonenumber" % "libphonenumber"                % LibPhoneNumberVersion
   )
 
   val test = Seq(
-    "org.scalatest"          %% "scalatest"               % ScalaTestVersion,
-    "org.scalatestplus"      %% "scalacheck-1-15"         % ScalaTestPlusVersion,
-    "org.scalatestplus"      %% "mockito-3-4"             % ScalaTestPlusVersion,
-    "org.scalatestplus.play" %% "scalatestplus-play"      % ScalaTestPlusPlayVersion,
-    "org.pegdown"             % "pegdown"                 % PegdownVersion,
-    "org.jsoup"               % "jsoup"                   % JsoupVersion,
-    "com.typesafe.play"      %% "play-test"               % PlayVersion.current,
-    "org.mockito"            %% "mockito-scala"           % MockitoScalaVersion,
-    "org.scalacheck"         %% "scalacheck"              % ScalaCheckVersion,
-    "wolfendale"             %% "scalacheck-gen-regexp"   % ScalaCheckRegexGenVersion,
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % HmrcMongoPlayVersion,
-    "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % BootstrapFrontendPlayVersion,
-    "com.vladsch.flexmark"    % "flexmark-all"            % FlexmarkVersion
+    "org.scalatest"              %% "scalatest"               % ScalaTestVersion,
+    "org.scalatestplus"          %% "scalacheck-1-15"         % ScalaTestPlusVersion,
+    "org.scalatestplus"          %% "mockito-3-4"             % ScalaTestPlusVersion,
+    "org.scalatestplus.play"     %% "scalatestplus-play"      % ScalaTestPlusPlayVersion,
+    "org.pegdown"                 % "pegdown"                 % PegdownVersion,
+    "org.jsoup"                   % "jsoup"                   % JsoupVersion,
+    "com.typesafe.play"          %% "play-test"               % PlayVersion.current,
+    "org.mockito"                %% "mockito-scala"           % MockitoScalaVersion,
+    "org.scalacheck"             %% "scalacheck"              % ScalaCheckVersion,
+    "wolfendale"                 %% "scalacheck-gen-regexp"   % ScalaCheckRegexGenVersion,
+    "uk.gov.hmrc.mongo"          %% "hmrc-mongo-test-play-28" % HmrcMongoPlayVersion,
+    "uk.gov.hmrc"                %% "bootstrap-test-play-28"  % BootstrapFrontendPlayVersion,
+    "com.vladsch.flexmark"        % "flexmark-all"            % FlexmarkVersion,
+    "com.softwaremill.quicklens" %% "quicklens"               % QuicklensVersion
   ).map(_ % "test, it")
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/test-utils/generators/ApplicationRequestGenerator.scala
+++ b/test-utils/generators/ApplicationRequestGenerator.scala
@@ -36,16 +36,18 @@ trait ApplicationRequestGenerator extends Generators {
 
   implicit lazy val arbitraryTraderDetail: Arbitrary[TraderDetail] = Arbitrary {
     for {
-      eori         <- arbitraryEoriNumberGen.arbitrary
-      businessName <- stringsWithMaxLength(100)
-      addressLine1 <- stringsWithMaxLength(100)
-      addressLine2 <- Gen.option(stringsWithMaxLength(100))
-      addressLine3 <- Gen.option(stringsWithMaxLength(100))
-      postCode     <- stringsWithMaxLength(10)
-      countryCode  <- Gen.oneOf("UK", "JP", "FR", "DE", "IT", "ES", "US")
-      phoneNumber  <- Gen.option(stringsWithMaxLength(25))
+      eori                              <- arbitraryEoriNumberGen.arbitrary
+      consentToDisclosureOfPersonalData <- Arbitrary.arbitrary[Boolean]
+      businessName                      <- stringsWithMaxLength(100)
+      addressLine1                      <- stringsWithMaxLength(100)
+      addressLine2                      <- Gen.option(stringsWithMaxLength(100))
+      addressLine3                      <- Gen.option(stringsWithMaxLength(100))
+      postCode                          <- stringsWithMaxLength(10)
+      countryCode                       <- Gen.oneOf("UK", "JP", "FR", "DE", "IT", "ES", "US")
+      phoneNumber                       <- Gen.option(stringsWithMaxLength(25))
     } yield TraderDetail(
       eori.value,
+      consentToDisclosureOfPersonalData,
       businessName,
       addressLine1,
       addressLine2,

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -45,17 +45,19 @@ trait ModelGenerators {
 
   implicit lazy val arbitraryCheckRegisteredDetails: Arbitrary[CheckRegisteredDetails] = Arbitrary {
     for {
-      value           <- arbitrary[Boolean]
-      eori            <- Gen.alphaStr.suchThat(_.nonEmpty)
-      name            <- Gen.alphaStr.suchThat(_.nonEmpty)
-      streetAndNumber <- Gen.alphaStr.suchThat(_.nonEmpty)
-      city            <- Gen.alphaStr.suchThat(_.nonEmpty)
-      country         <- Gen.alphaStr.suchThat(_.nonEmpty)
-      postalCode      <- Gen.option(Gen.alphaStr.suchThat(_.nonEmpty))
-      phoneNumber     <- Gen.option(Gen.alphaStr.suchThat(_.nonEmpty))
+      value                             <- arbitrary[Boolean]
+      eori                              <- Gen.alphaStr.suchThat(_.nonEmpty)
+      consentToDisclosureOfPersonalData <- arbitrary[Boolean]
+      name                              <- Gen.alphaStr.suchThat(_.nonEmpty)
+      streetAndNumber                   <- Gen.alphaStr.suchThat(_.nonEmpty)
+      city                              <- Gen.alphaStr.suchThat(_.nonEmpty)
+      country                           <- Gen.alphaStr.suchThat(_.nonEmpty)
+      postalCode                        <- Gen.option(Gen.alphaStr.suchThat(_.nonEmpty))
+      phoneNumber                       <- Gen.option(Gen.alphaStr.suchThat(_.nonEmpty))
     } yield CheckRegisteredDetails(
       value,
       eori,
+      consentToDisclosureOfPersonalData,
       name,
       streetAndNumber,
       city,

--- a/test-utils/generators/TraderDetailsGenerator.scala
+++ b/test-utils/generators/TraderDetailsGenerator.scala
@@ -23,6 +23,7 @@ import play.api.http.Status
 
 import models._
 import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
 import wolfendale.scalacheck.regexp.RegexpGen
 
 trait TraderDetailsGenerator extends Generators {
@@ -59,15 +60,17 @@ trait TraderDetailsGenerator extends Generators {
   implicit lazy val arbitraryTraderDetailsWithCountryCode: Arbitrary[TraderDetailsWithCountryCode] =
     Arbitrary {
       for {
-        eoriNumber         <- arbitraryEoriNumberGen.arbitrary
-        cdsFullName        <- stringsWithMaxLength(512)
-        streetAndNumber    <- stringsWithMaxLength(70)
-        city               <- stringsWithMaxLength(35)
-        country            <- stringsWithMaxLength(2)
-        postalCode         <- Gen.option(stringsWithMaxLength(9))
-        contactInformation <- Gen.option(contactInformationGen)
+        eoriNumber                        <- arbitraryEoriNumberGen.arbitrary
+        consentToDisclosureOfPersonalData <- arbitrary[Boolean]
+        cdsFullName                       <- stringsWithMaxLength(512)
+        streetAndNumber                   <- stringsWithMaxLength(70)
+        city                              <- stringsWithMaxLength(35)
+        country                           <- stringsWithMaxLength(2)
+        postalCode                        <- Gen.option(stringsWithMaxLength(9))
+        contactInformation                <- Gen.option(contactInformationGen)
       } yield TraderDetailsWithCountryCode(
         eoriNumber.value,
+        consentToDisclosureOfPersonalData,
         cdsFullName,
         CDSEstablishmentAddress(streetAndNumber, city, country, postalCode),
         contactInformation

--- a/test/controllers/CheckRegisteredDetailsControllerSpec.scala
+++ b/test/controllers/CheckRegisteredDetailsControllerSpec.scala
@@ -30,11 +30,15 @@ import models._
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
+import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatestplus.mockito.MockitoSugar
 import pages.CheckRegisteredDetailsPage
 import repositories.SessionRepository
 
-class CheckRegisteredDetailsControllerSpec extends SpecBase with MockitoSugar {
+class CheckRegisteredDetailsControllerSpec
+    extends SpecBase
+    with MockitoSugar
+    with TableDrivenPropertyChecks {
 
   def onwardRoute = Call("GET", "/foo")
 
@@ -49,6 +53,7 @@ class CheckRegisteredDetailsControllerSpec extends SpecBase with MockitoSugar {
     val registeredDetails: CheckRegisteredDetails = CheckRegisteredDetails(
       value = false,
       eori = "GB123456789012345",
+      consentToDisclosureOfPersonalData = true,
       name = "Test Name",
       streetAndNumber = "Test Street 1",
       city = "Test City",
@@ -72,6 +77,7 @@ class CheckRegisteredDetailsControllerSpec extends SpecBase with MockitoSugar {
 
     val traderDetailsWithCountryCode = TraderDetailsWithCountryCode(
       EORINo = registeredDetails.eori,
+      consentToDisclosureOfPersonalData = true,
       CDSFullName = registeredDetails.name,
       CDSEstablishmentAddress = CDSEstablishmentAddress(
         streetAndNumber = registeredDetails.streetAndNumber,
@@ -86,43 +92,60 @@ class CheckRegisteredDetailsControllerSpec extends SpecBase with MockitoSugar {
       .set(CheckRegisteredDetailsPage, registeredDetails)
       .success
       .value
-    "must return OK and the correct view for a GET" in {
 
-      val mockBackendConnector = mock[BackendConnector]
+    val consentToDisclosureOfPersonalDataScenarios =
+      Table("consentToDisclosureOfPersonalData", true, false)
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
-        .overrides(
-          bind[BackendConnector].toInstance(mockBackendConnector)
-        )
-        .build()
+    forAll(consentToDisclosureOfPersonalDataScenarios) {
+      consentValue =>
+        s"must return OK and the correct view for a GET when consentToDisclosureOfPersonalData is $consentValue" in {
 
-      when(
-        mockBackendConnector.getTraderDetails(any(), any())(any(), any())
-      ) thenReturn Future
-        .successful(
-          Right(traderDetailsWithCountryCode)
-        )
+          val mockBackendConnector = mock[BackendConnector]
 
-      running(application) {
-        val request = FakeRequest(GET, checkRegisteredDetailsRoute)
+          val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
+            .overrides(
+              bind[BackendConnector].toInstance(mockBackendConnector)
+            )
+            .build()
 
-        val result = route(application, request).value
+          when(
+            mockBackendConnector.getTraderDetails(any(), any())(any(), any())
+          ) thenReturn Future
+            .successful(
+              Right(
+                traderDetailsWithCountryCode.copy(consentToDisclosureOfPersonalData = consentValue)
+              )
+            )
 
-        status(result) mustEqual OK
-      }
-    }
+          running(application) {
+            val request = FakeRequest(GET, checkRegisteredDetailsRoute)
 
-    "must populate the view correctly on a GET when the question has previously been answered" in {
+            val result = route(application, request).value
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+            status(result) mustEqual OK
+          }
+        }
 
-      running(application) {
-        val request = FakeRequest(GET, checkRegisteredDetailsRoute)
+        s"must return correct view for a GET when question has been answered previously and consentToDisclosureOfPersonalData is $consentValue" in {
 
-        val result = route(application, request).value
+          val previousUserAnswers = emptyUserAnswers
+            .set(
+              CheckRegisteredDetailsPage,
+              registeredDetails.copy(consentToDisclosureOfPersonalData = consentValue)
+            )
+            .success
+            .value
 
-        status(result) mustEqual OK
-      }
+          val application = applicationBuilder(userAnswers = Some(previousUserAnswers)).build()
+
+          running(application) {
+            val request = FakeRequest(GET, checkRegisteredDetailsRoute)
+
+            val result = route(application, request).value
+
+            status(result) mustEqual OK
+          }
+        }
     }
 
     "must redirect to the next page when valid data is submitted" in {

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -22,7 +22,6 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AffinityGroup
-import uk.gov.hmrc.http.HeaderCarrier
 
 import base.SpecBase
 import models._
@@ -42,8 +41,7 @@ class CheckYourAnswersControllerSpec
     with MockitoSugar
     with BeforeAndAfterEach {
 
-  private implicit lazy val headerCarrier: HeaderCarrier = HeaderCarrier()
-  private val mockSubmissionService                      = mock[SubmissionService]
+  private val mockSubmissionService = mock[SubmissionService]
 
   override def beforeEach(): Unit = {
     Mockito.reset(mockSubmissionService)
@@ -99,6 +97,7 @@ class CheckYourAnswersControllerSpec
                 CheckRegisteredDetails(
                   value = true,
                   eori = "eori",
+                  consentToDisclosureOfPersonalData = true,
                   name = "name",
                   streetAndNumber = "streetAndNumber",
                   city = "city",

--- a/test/controllers/CheckYourAnswersForAgentsControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersForAgentsControllerSpec.scala
@@ -104,6 +104,7 @@ class CheckYourAnswersForAgentsControllerSpec
                 CheckRegisteredDetails(
                   value = true,
                   eori = "eori",
+                  consentToDisclosureOfPersonalData = true,
                   name = "name",
                   streetAndNumber = "streetAndNumber",
                   city = "city",

--- a/test/controllers/EORIBeUpToDateControllerSpec.scala
+++ b/test/controllers/EORIBeUpToDateControllerSpec.scala
@@ -42,6 +42,7 @@ class EORIBeUpToDateControllerSpec extends SpecBase with MockitoSugar {
   val registeredDetails: CheckRegisteredDetails = CheckRegisteredDetails(
     value = false,
     eori = "GB123456789012345",
+    consentToDisclosureOfPersonalData = true,
     name = "Test Name",
     streetAndNumber = "Test Street 1",
     city = "Test City",

--- a/test/controllers/ViewApplicationControllerSpec.scala
+++ b/test/controllers/ViewApplicationControllerSpec.scala
@@ -32,6 +32,7 @@ import models._
 import models.requests._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
+import org.scalacheck.Arbitrary
 import org.scalatestplus.mockito.MockitoSugar
 import viewmodels.ApplicationViewModel
 import views.html.ViewApplicationView
@@ -85,8 +86,11 @@ object ViewApplicationControllerSpec extends Generators {
 
   val randomString: String = stringsWithMaxLength(8).sample.get
 
+  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
+
   val eoriDetails = TraderDetail(
     eori = randomString,
+    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),
@@ -146,6 +150,7 @@ object ViewApplicationControllerSpec extends Generators {
     |"draftId": "$draftId",
     |"eoriDetails": {
     |  "eori": "$randomString",
+    |  "consentToDisclosureOfPersonalData": $randomBoolean
     |  "businessName": "$randomString",
     |  "addressLine1": "$randomString",
     |  "addressLine2": "$randomString",

--- a/test/models/CheckRegisteredDetailsSpec.scala
+++ b/test/models/CheckRegisteredDetailsSpec.scala
@@ -37,6 +37,7 @@ class CheckRegisteredDetailsSpec
                       |{
                       |  "value": true,
                       |  "eori": "GB123456789012",
+                      |  "consentToDisclosureOfPersonalData": true,
                       |  "name": "name",
                       |  "streetAndNumber": "streetAndNumber",
                       |  "city": "city",
@@ -49,6 +50,7 @@ class CheckRegisteredDetailsSpec
     val validDetails = CheckRegisteredDetails(
       value = true,
       eori = "GB123456789012",
+      consentToDisclosureOfPersonalData = true,
       name = "name",
       streetAndNumber = "streetAndNumber",
       city = "city",

--- a/test/models/requests/ApplicationRequestSpec.scala
+++ b/test/models/requests/ApplicationRequestSpec.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.auth.core.AffinityGroup
 import generators._
 import models._
 import models.DraftId
+import org.scalacheck.Arbitrary
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -88,6 +89,7 @@ class ApplicationRequestSpec
                 CheckRegisteredDetails(
                   value = true,
                   eori = randomString,
+                  consentToDisclosureOfPersonalData = randomBoolean,
                   name = randomString,
                   streetAndNumber = randomString,
                   city = randomString,
@@ -168,12 +170,15 @@ class ApplicationRequestSpec
 object ApplicationRequestSpec extends Generators {
   val randomString: String = stringsWithMaxLength(8).sample.get
 
+  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
+
   val draftId: DraftId = DraftId(1)
 
   val emptyUserAnswers: UserAnswers = UserAnswers("a", draftId)
 
   val eoriDetails = TraderDetail(
     eori = randomString,
+    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),
@@ -215,6 +220,7 @@ object ApplicationRequestSpec extends Generators {
     |"draftId": "$draftId",
     |"trader": {
     |  "eori": "$randomString",
+    |  "consentToDisclosureOfPersonalData": $randomBoolean,
     |  "businessName": "$randomString",
     |  "addressLine1": "$randomString",
     |  "addressLine2": "$randomString",

--- a/test/models/requests/ContactDetailsSpec.scala
+++ b/test/models/requests/ContactDetailsSpec.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.auth.core.AffinityGroup
 
 import generators._
 import models._
+import org.scalacheck.Arbitrary
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -85,6 +86,7 @@ object ContactDetailsSpec extends Generators {
   val CheckRegDetails = CheckRegisteredDetails(
     true,
     "eori",
+    true,
     "name",
     "streetAndNumber",
     "city",
@@ -94,6 +96,8 @@ object ContactDetailsSpec extends Generators {
   )
 
   val randomString: String = stringsWithMaxLength(8).sample.get
+
+  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
 
   val draftId: DraftId = DraftId(1)
 
@@ -117,6 +121,7 @@ object ContactDetailsSpec extends Generators {
   )
   val eoriDetails               = TraderDetail(
     eori = randomString,
+    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),

--- a/test/navigation/CheckModeNavigatorSpec.scala
+++ b/test/navigation/CheckModeNavigatorSpec.scala
@@ -690,6 +690,7 @@ class CheckModeNavigatorSpec extends SpecBase {
           def registeredDetails(value: Boolean) = CheckRegisteredDetails(
             value,
             eori = "eori",
+            consentToDisclosureOfPersonalData = true,
             name = "name",
             streetAndNumber = "streetAndNumber",
             city = "city",

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -364,6 +364,7 @@ class NavigatorSpec extends SpecBase {
         val data = CheckRegisteredDetails(
           value = true,
           eori = "GB1234567890",
+          consentToDisclosureOfPersonalData = true,
           name = "name",
           streetAndNumber = "street",
           city = "city",

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -57,7 +57,7 @@ class SubmissionServiceSpec
   private val applicationId      = ApplicationId(1)
   private val applicationRequest = ApplicationRequest(
     draftId = DraftId(0),
-    trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None),
+    trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None),
     agent = None,
     contact = ContactDetails("name", "email", None),
     requestedMethod = MethodOne(None, None, None),

--- a/test/viewmodels/ApplicationViewModelSpec.scala
+++ b/test/viewmodels/ApplicationViewModelSpec.scala
@@ -18,20 +18,17 @@ package viewmodels
 
 import java.time.{Clock, Instant, ZoneOffset}
 
-import scala.util.Try
-
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Text, Value}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content._
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow}
 
 import base.SpecBase
+import com.softwaremill.quicklens._
 import generators.Generators
 import models._
-import models.{BusinessContactDetails, UserAnswers, WhatIsYourRoleAsImporter}
 import models.requests._
-import pages.{BusinessContactDetailsPage, WhatIsYourRoleAsImporterPage}
+import org.scalacheck.Arbitrary
 
 class ApplicationViewModelSpec extends SpecBase {
   import ApplicationViewModelSpec._
@@ -41,32 +38,56 @@ class ApplicationViewModelSpec extends SpecBase {
     implicit val m: Messages = play.api.test.Helpers.stubMessages()
 
     "when given a valid application" - {
-      val result: ApplicationViewModel = ApplicationViewModel(application)
 
-      "must create rows for the eori details" in {
-        result.eori.rows must be(
-          Seq(
-            SummaryListRow(
-              Key(Text("checkYourAnswers.eori.number.label")),
-              Value(Text(randomString))
-            ),
-            SummaryListRow(
-              Key(Text("checkYourAnswers.eori.name.label")),
-              Value(Text(randomString))
-            ),
-            SummaryListRow(
-              Key(Text("checkYourAnswers.eori.address.label")),
-              Value(
-                HtmlContent(
-                  s"${randomString}<br>${randomString}<br>${randomString}<br>${randomString}"
+      "when trader's consentToDisclosureOfPersonalData = true" - {
+        val result = ApplicationViewModel(
+          application.modify(_.trader.consentToDisclosureOfPersonalData).setTo(true)
+        )
+
+        "must create rows for the eori details" in {
+          result.eori.rows must be(
+            Seq(
+              SummaryListRow(
+                Key(Text("checkYourAnswers.eori.number.label")),
+                Value(Text(randomString))
+              ),
+              SummaryListRow(
+                Key(Text("checkYourAnswers.eori.name.label")),
+                Value(Text(randomString))
+              ),
+              SummaryListRow(
+                Key(Text("checkYourAnswers.eori.address.label")),
+                Value(
+                  HtmlContent(
+                    s"${randomString}<br>${randomString}<br>${randomString}<br>${randomString}"
+                  )
                 )
               )
             )
           )
+        }
+      }
+
+      "when trader's consentToDisclosureOfPersonalData = false" - {
+        val result = ApplicationViewModel(
+          application.modify(_.trader.consentToDisclosureOfPersonalData).setTo(false)
         )
+
+        "must create rows for the eori details" in {
+          result.eori.rows must be(
+            Seq(
+              SummaryListRow(
+                Key(Text("checkYourAnswers.eori.number.label")),
+                Value(Text(randomString))
+              )
+            )
+          )
+        }
       }
 
       "must create row for the applicant" in {
+        val result = ApplicationViewModel(application)
+
         result.applicant.rows must be(
           Seq(
             SummaryListRow(
@@ -95,8 +116,11 @@ class ApplicationViewModelSpec extends SpecBase {
 object ApplicationViewModelSpec extends Generators {
   val randomString: String = stringsWithMaxLength(8).sample.get
 
+  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
+
   val eoriDetails = TraderDetail(
     eori = randomString,
+    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),

--- a/test/viewmodels/checkAnswers/summary/BusinessEoriDetailsSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/summary/BusinessEoriDetailsSummarySpec.scala
@@ -16,34 +16,28 @@
 
 package viewmodels.checkAnswers.summary
 
-import scala.util.Try
-
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{HtmlContent, Text, Value}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
 
 import base.SpecBase
 import generators.Generators
-import models.{CheckRegisteredDetails, UserAnswers}
+import models.CheckRegisteredDetails
 import pages.CheckRegisteredDetailsPage
 
 class BusinessEoriDetailsSummarySpec extends SpecBase with Generators {
 
-  val allAnswersInput: Try[UserAnswers] =
-    emptyUserAnswers
-      .set(
-        CheckRegisteredDetailsPage,
-        CheckRegisteredDetails(
-          value = true,
-          EoriNumber,
-          RegisteredName,
-          StreetAndNumber,
-          City,
-          Country,
-          Some(Postcode),
-          Some(phoneNumber)
-        )
-      )
+  private val registeredDetails: CheckRegisteredDetails = CheckRegisteredDetails(
+    value = true,
+    EoriNumber,
+    consentToDisclosureOfPersonalData = true,
+    RegisteredName,
+    StreetAndNumber,
+    City,
+    Country,
+    Some(Postcode),
+    Some(phoneNumber)
+  )
 
   "IndividualEoriDetailsSummary" - {
     implicit val m: Messages = play.api.test.Helpers.stubMessages()
@@ -58,8 +52,10 @@ class BusinessEoriDetailsSummarySpec extends SpecBase with Generators {
     }
 
     "when the user has answers for all relevant pages" - {
-      val summary = BusinessEoriDetailsSummary(allAnswersInput.success.value)
-      val rows    = summary.rows.rows.map(row => (row.key, row.value))
+      val userAnswers =
+        emptyUserAnswers.set(CheckRegisteredDetailsPage, registeredDetails).success.value
+      val summary     = BusinessEoriDetailsSummary(userAnswers)
+      val rows        = summary.rows.rows.map(row => (row.key, row.value))
 
       "must create rows for each page" in {
         rows.length mustBe 3
@@ -88,6 +84,27 @@ class BusinessEoriDetailsSummarySpec extends SpecBase with Generators {
           (
             Key(Text("checkYourAnswersForAgents.business.address.label")),
             Value(HtmlContent(s"$StreetAndNumber<br>$City<br>$Postcode<br>$Country"))
+          )
+        )
+      }
+    }
+
+    "when consentToDisclosureOfPersonalData is false" - {
+      val userAnswers = emptyUserAnswers
+        .set(
+          CheckRegisteredDetailsPage,
+          registeredDetails.copy(consentToDisclosureOfPersonalData = false)
+        )
+        .success
+        .value
+      val summary     = BusinessEoriDetailsSummary(userAnswers)
+      val rows        = summary.rows.rows.map(row => (row.key, row.value))
+
+      "create only EORI number row" in {
+        rows must contain theSameElementsAs Seq(
+          (
+            Key(Text("checkYourAnswersForAgents.business.eori.number.label")),
+            Value(Text(EoriNumber))
           )
         )
       }

--- a/test/viewmodels/checkAnswers/summary/IndividualEoriDetailsSummarySpec.scala
+++ b/test/viewmodels/checkAnswers/summary/IndividualEoriDetailsSummarySpec.scala
@@ -16,33 +16,27 @@
 
 package viewmodels.checkAnswers.summary
 
-import scala.util.Try
-
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{HtmlContent, Text, Value}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
 
 import base.SpecBase
-import models.{CheckRegisteredDetails, UserAnswers}
+import models.CheckRegisteredDetails
 import pages.CheckRegisteredDetailsPage
 
 class IndividualEoriDetailsSummarySpec extends SpecBase {
 
-  val allAnswersInput: Try[UserAnswers] =
-    emptyUserAnswers
-      .set(
-        CheckRegisteredDetailsPage,
-        CheckRegisteredDetails(
-          value = true,
-          EoriNumber,
-          RegisteredName,
-          StreetAndNumber,
-          City,
-          Country,
-          Some(Postcode),
-          Some(phoneNumber)
-        )
-      )
+  private val registeredDetails: CheckRegisteredDetails = CheckRegisteredDetails(
+    value = true,
+    EoriNumber,
+    consentToDisclosureOfPersonalData = true,
+    RegisteredName,
+    StreetAndNumber,
+    City,
+    Country,
+    Some(Postcode),
+    Some(phoneNumber)
+  )
 
   "IndividualEoriDetailsSummary" - {
     implicit val m: Messages = play.api.test.Helpers.stubMessages()
@@ -57,8 +51,10 @@ class IndividualEoriDetailsSummarySpec extends SpecBase {
     }
 
     "when the user has answers for all relevant pages" - {
-      val summary = IndividualEoriDetailsSummary(allAnswersInput.success.value)
-      val rows    = summary.rows.rows.map(row => (row.key, row.value))
+      val userAnswers =
+        emptyUserAnswers.set(CheckRegisteredDetailsPage, registeredDetails).success.value
+      val summary     = IndividualEoriDetailsSummary(userAnswers)
+      val rows        = summary.rows.rows.map(row => (row.key, row.value))
 
       "must create rows for each page" in {
         rows.length mustBe 3
@@ -87,6 +83,27 @@ class IndividualEoriDetailsSummarySpec extends SpecBase {
           (
             Key(Text("checkYourAnswers.eori.address.label")),
             Value(HtmlContent(s"$StreetAndNumber<br>$City<br>$Postcode<br>$Country"))
+          )
+        )
+      }
+    }
+
+    "when consentToDisclosureOfPersonalData is false" - {
+      val userAnswers = emptyUserAnswers
+        .set(
+          CheckRegisteredDetailsPage,
+          registeredDetails.copy(consentToDisclosureOfPersonalData = false)
+        )
+        .success
+        .value
+      val summary     = IndividualEoriDetailsSummary(userAnswers)
+      val rows        = summary.rows.rows.map(row => (row.key, row.value))
+
+      "create only EORI number row" in {
+        rows must contain theSameElementsAs Seq(
+          (
+            Key(Text("checkYourAnswers.eori.number.label")),
+            Value(Text(EoriNumber))
           )
         )
       }


### PR DESCRIPTION
This hides the trader's personal details when `consentToDisclosureOfPersonalData` is false.

<img width="400" alt="Screenshot 2023-04-14 at 09 24 00" src="https://user-images.githubusercontent.com/8526655/231990714-26440512-a499-4809-a09b-0b2758e44260.png">

<img width="400" alt="Screenshot 2023-04-14 at 09 25 09" src="https://user-images.githubusercontent.com/8526655/231990756-c3d0a82a-244a-4ee4-8016-5e2a97024a72.png">

<img width="400" alt="Screenshot 2023-04-14 at 09 25 30" src="https://user-images.githubusercontent.com/8526655/231990797-1d77928e-072e-47af-8188-cb6cfc8411a5.png">
