### PR TITLE
Exclude trader details from view application page

### DIFF
--- a/app/connectors/UserAnswersConnector.scala
+++ b/app/connectors/UserAnswersConnector.scala
@@ -16,16 +16,20 @@
 
 package connectors
 
-import config.FrontendAppConfig
-import models.{Done, DraftId, UserAnswers}
+import javax.inject.Inject
+
+import scala.concurrent.{ExecutionContext, Future}
+
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
 import uk.gov.hmrc.http.client.HttpClientV2
 
-import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
+import config.FrontendAppConfig
+import models.{Done, DraftId, UserAnswers}
 
-class UserAnswersConnector @Inject()(config: FrontendAppConfig, httpClient: HttpClientV2)(implicit ec: ExecutionContext) {
+class UserAnswersConnector @Inject() (config: FrontendAppConfig, httpClient: HttpClientV2)(implicit
+  ec: ExecutionContext
+) {
 
   private val backendUrl = config.advanceValuationRulingsBackendURL
 

--- a/app/models/requests/ApplicationRequest.scala
+++ b/app/models/requests/ApplicationRequest.scala
@@ -70,7 +70,7 @@ object GoodsDetails {
 
 final case class TraderDetail(
   eori: String,
-  consentToDisclosureOfPersonalData: Boolean,
+//  consentToDisclosureOfPersonalData: Boolean,
   businessName: String,
   addressLine1: String,
   addressLine2: Option[String],
@@ -89,7 +89,7 @@ object TraderDetail {
       (crd: CheckRegisteredDetails) =>
         TraderDetail(
           eori = crd.eori,
-          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
+//          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
           businessName = crd.name,
           addressLine1 = crd.streetAndNumber,
           addressLine2 = Some(crd.city),
@@ -107,7 +107,7 @@ object TraderDetail {
       (crd) =>
         TraderDetail(
           eori = crd.eori,
-          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
+//          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
           businessName = crd.name,
           addressLine1 = crd.streetAndNumber,
           addressLine2 = Some(crd.city),

--- a/app/models/requests/ApplicationRequest.scala
+++ b/app/models/requests/ApplicationRequest.scala
@@ -70,7 +70,6 @@ object GoodsDetails {
 
 final case class TraderDetail(
   eori: String,
-//  consentToDisclosureOfPersonalData: Boolean,
   businessName: String,
   addressLine1: String,
   addressLine2: Option[String],
@@ -89,7 +88,6 @@ object TraderDetail {
       (crd: CheckRegisteredDetails) =>
         TraderDetail(
           eori = crd.eori,
-//          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
           businessName = crd.name,
           addressLine1 = crd.streetAndNumber,
           addressLine2 = Some(crd.city),
@@ -107,7 +105,6 @@ object TraderDetail {
       (crd) =>
         TraderDetail(
           eori = crd.eori,
-//          consentToDisclosureOfPersonalData = crd.consentToDisclosureOfPersonalData,
           businessName = crd.name,
           addressLine1 = crd.streetAndNumber,
           addressLine2 = Some(crd.city),

--- a/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
+++ b/app/viewmodels/checkAnswers/CheckRegisteredDetailsSummary.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 
 import controllers.routes
-import models.{CheckMode, CheckRegisteredDetails, UserAnswers}
+import models.{CheckMode, CheckRegisteredDetails, EoriNumber, UserAnswers}
 import models.requests._
 import pages.CheckRegisteredDetailsPage
 import viewmodels.govuk.summarylist._
@@ -71,12 +71,10 @@ object CheckRegisteredDetailsSummary {
       )
     )
 
-  private def registeredNumberRow(answer: CheckRegisteredDetails)(implicit
-    messages: Messages
-  ): SummaryListRow =
+  private def registeredNumberRow(eoriNumber: EoriNumber)(implicit messages: Messages) =
     SummaryListRowViewModel(
       key = "checkYourAnswers.eori.number.label",
-      value = ValueViewModel(HtmlFormat.escape(answer.eori).body),
+      value = ValueViewModel(HtmlFormat.escape(eoriNumber.value).body),
       actions = Seq(
         ActionItemViewModel(
           "site.change",
@@ -89,29 +87,14 @@ object CheckRegisteredDetailsSummary {
   def rows(userAnswer: UserAnswers)(implicit messages: Messages): Option[Seq[SummaryListRow]] =
     for {
       contactDetails <- userAnswer.get(CheckRegisteredDetailsPage)
-      number          = registeredNumberRow(contactDetails)
+      number          = registeredNumberRow(EoriNumber(contactDetails.eori))
     } yield number +: getPersonalDetails(contactDetails)
 
   def rows(
     application: Application
-  )(implicit messages: Messages): Seq[SummaryListRow] = {
-
-    val postCode       =
-      if (application.trader.postcode.isEmpty) None else Some(application.trader.postcode)
-    val contactDetails = models.CheckRegisteredDetails(
-      value = true,
-      eori = application.trader.eori,
-      name = application.trader.businessName,
-      streetAndNumber = application.trader.addressLine1,
-      city = application.trader.addressLine2.getOrElse(""),
-      country = application.trader.countryCode,
-      postalCode = postCode,
-      phoneNumber = application.trader.phoneNumber,
-      consentToDisclosureOfPersonalData = application.trader.consentToDisclosureOfPersonalData
-    )
-
-    registeredNumberRow(contactDetails) +: getPersonalDetails(contactDetails)
-  }
+  )(implicit messages: Messages): Seq[SummaryListRow] = Seq(
+    registeredNumberRow(EoriNumber(application.trader.eori))
+  )
 
   private def getPersonalDetails(
     registeredDetails: CheckRegisteredDetails

--- a/app/viewmodels/checkAnswers/summary/ApplicantSummary.scala
+++ b/app/viewmodels/checkAnswers/summary/ApplicantSummary.scala
@@ -22,18 +22,12 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 
 import models.UserAnswers
-import models.requests.Application
 import viewmodels.checkAnswers._
 import viewmodels.govuk.summarylist._
 
 sealed trait ApplicantSummary {
   def removeActions(): ApplicantSummary
   def rows: SummaryList
-}
-
-object ApplicantSummary {
-  def apply(application: Application)(implicit messages: Messages) =
-    CheckRegisteredDetailsSummary.rows(application).map(_.copy(actions = None))
 }
 
 case class IndividualApplicantSummary(rows: SummaryList) extends ApplicantSummary {

--- a/app/views/components/ForYourRecords.scala.html
+++ b/app/views/components/ForYourRecords.scala.html
@@ -35,9 +35,6 @@
   
   <div class="govuk-grid-column-one-half">
     @applicationSummaryList(appModel.eori)
-  </div>
-
-  <div class="govuk-grid-column-one-half">
     @applicationSummaryList(appModel.applicant)
   </div>
 </div>
@@ -61,5 +58,4 @@
       <span class="footer-page-date">HMRC @lastUpdated</span>
     </div>
   </div>
-</div>
 </div>

--- a/it/connectors/BackendConnectorSpec.scala
+++ b/it/connectors/BackendConnectorSpec.scala
@@ -119,7 +119,7 @@ class BackendConnectorSpec
     val response           = ApplicationSubmissionResponse(applicationId)
     val applicationRequest = ApplicationRequest(
       draftId = DraftId(0),
-      trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None),
+      trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None),
       agent = None,
       contact = ContactDetails("name", "email", None),
       requestedMethod = MethodOne(None, None, None),

--- a/it/connectors/UserAnswersConnectorSpec.scala
+++ b/it/connectors/UserAnswersConnectorSpec.scala
@@ -1,17 +1,15 @@
 package connectors
 
+import java.time.Instant
+
+import play.api.libs.json.Json
+
 import com.github.tomakehurst.wiremock.client.WireMock._
 import models.{DraftId, UserAnswers}
 import org.scalatest.OptionValues
-import play.api.libs.json.Json
 import utils.{BaseIntegrationSpec, WireMockHelper}
 
-import java.time.Instant
-
-class UserAnswersConnectorSpec
-  extends BaseIntegrationSpec
-    with WireMockHelper
-    with OptionValues {
+class UserAnswersConnectorSpec extends BaseIntegrationSpec with WireMockHelper with OptionValues {
 
   override def beforeAll(): Unit = {
     super.beforeAll()

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,7 +21,6 @@ object AppDependencies {
   val HmrcMongoTestPlayVersion  = "0.74.0"
   val FlexmarkVersion           = "0.62.2"
   val EnumeratumVersion         = "1.6.3"
-  val QuicklensVersion          = "1.9.1"
   val ObjectStoreVersion        = "1.0.0"
   val InternalAuthVersion       = "1.2.0"
   val LibPhoneNumberVersion     = "8.12.47"
@@ -52,8 +51,7 @@ object AppDependencies {
     "wolfendale"                 %% "scalacheck-gen-regexp"   % ScalaCheckRegexGenVersion,
     "uk.gov.hmrc.mongo"          %% "hmrc-mongo-test-play-28" % HmrcMongoPlayVersion,
     "uk.gov.hmrc"                %% "bootstrap-test-play-28"  % BootstrapFrontendPlayVersion,
-    "com.vladsch.flexmark"        % "flexmark-all"            % FlexmarkVersion,
-    "com.softwaremill.quicklens" %% "quicklens"               % QuicklensVersion
+    "com.vladsch.flexmark"        % "flexmark-all"            % FlexmarkVersion
   ).map(_ % "test, it")
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/test-utils/generators/ApplicationRequestGenerator.scala
+++ b/test-utils/generators/ApplicationRequestGenerator.scala
@@ -36,18 +36,16 @@ trait ApplicationRequestGenerator extends Generators {
 
   implicit lazy val arbitraryTraderDetail: Arbitrary[TraderDetail] = Arbitrary {
     for {
-      eori                              <- arbitraryEoriNumberGen.arbitrary
-      consentToDisclosureOfPersonalData <- Arbitrary.arbitrary[Boolean]
-      businessName                      <- stringsWithMaxLength(100)
-      addressLine1                      <- stringsWithMaxLength(100)
-      addressLine2                      <- Gen.option(stringsWithMaxLength(100))
-      addressLine3                      <- Gen.option(stringsWithMaxLength(100))
-      postCode                          <- stringsWithMaxLength(10)
-      countryCode                       <- Gen.oneOf("UK", "JP", "FR", "DE", "IT", "ES", "US")
-      phoneNumber                       <- Gen.option(stringsWithMaxLength(25))
+      eori         <- arbitraryEoriNumberGen.arbitrary
+      businessName <- stringsWithMaxLength(100)
+      addressLine1 <- stringsWithMaxLength(100)
+      addressLine2 <- Gen.option(stringsWithMaxLength(100))
+      addressLine3 <- Gen.option(stringsWithMaxLength(100))
+      postCode     <- stringsWithMaxLength(10)
+      countryCode  <- Gen.oneOf("UK", "JP", "FR", "DE", "IT", "ES", "US")
+      phoneNumber  <- Gen.option(stringsWithMaxLength(25))
     } yield TraderDetail(
       eori.value,
-      consentToDisclosureOfPersonalData,
       businessName,
       addressLine1,
       addressLine2,

--- a/test/controllers/ViewApplicationControllerSpec.scala
+++ b/test/controllers/ViewApplicationControllerSpec.scala
@@ -86,11 +86,8 @@ object ViewApplicationControllerSpec extends Generators {
 
   val randomString: String = stringsWithMaxLength(8).sample.get
 
-  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
-
   val eoriDetails = TraderDetail(
     eori = randomString,
-    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),
@@ -150,7 +147,6 @@ object ViewApplicationControllerSpec extends Generators {
     |"draftId": "$draftId",
     |"eoriDetails": {
     |  "eori": "$randomString",
-    |  "consentToDisclosureOfPersonalData": $randomBoolean
     |  "businessName": "$randomString",
     |  "addressLine1": "$randomString",
     |  "addressLine2": "$randomString",

--- a/test/models/requests/ApplicationRequestSpec.scala
+++ b/test/models/requests/ApplicationRequestSpec.scala
@@ -178,7 +178,6 @@ object ApplicationRequestSpec extends Generators {
 
   val eoriDetails = TraderDetail(
     eori = randomString,
-    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),
@@ -220,7 +219,6 @@ object ApplicationRequestSpec extends Generators {
     |"draftId": "$draftId",
     |"trader": {
     |  "eori": "$randomString",
-    |  "consentToDisclosureOfPersonalData": $randomBoolean,
     |  "businessName": "$randomString",
     |  "addressLine1": "$randomString",
     |  "addressLine2": "$randomString",

--- a/test/models/requests/ContactDetailsSpec.scala
+++ b/test/models/requests/ContactDetailsSpec.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.auth.core.AffinityGroup
 
 import generators._
 import models._
-import org.scalacheck.Arbitrary
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -97,8 +96,6 @@ object ContactDetailsSpec extends Generators {
 
   val randomString: String = stringsWithMaxLength(8).sample.get
 
-  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
-
   val draftId: DraftId = DraftId(1)
 
   val emptyUserAnswers: UserAnswers = UserAnswers("a", draftId)
@@ -120,7 +117,6 @@ object ContactDetailsSpec extends Generators {
   )
   val eoriDetails               = TraderDetail(
     eori = randomString,
-    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -54,10 +54,9 @@ class SubmissionServiceSpec
 
   private val service = app.injector.instanceOf[SubmissionService]
 
-  private val applicationId      = ApplicationId(1)
   private val applicationRequest = ApplicationRequest(
     draftId = DraftId(0),
-    trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None),
+    trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None),
     agent = None,
     contact = ContactDetails("name", "email", None),
     requestedMethod = MethodOne(None, None, None),
@@ -114,8 +113,6 @@ class SubmissionServiceSpec
     }
 
     "must return a failed future when submitting the application fails" in {
-
-      val response = ApplicationSubmissionResponse(ApplicationId(1))
 
       when(mockBackendConnector.submitApplication(any())(any()))
         .thenReturn(Future.failed(new RuntimeException("foo")))

--- a/test/viewmodels/ApplicationViewModelSpec.scala
+++ b/test/viewmodels/ApplicationViewModelSpec.scala
@@ -20,15 +20,12 @@ import java.time.{Clock, Instant, ZoneOffset}
 
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.{Text, Value}
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content._
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow}
 
 import base.SpecBase
-import com.softwaremill.quicklens._
 import generators.Generators
 import models._
 import models.requests._
-import org.scalacheck.Arbitrary
 
 class ApplicationViewModelSpec extends SpecBase {
   import ApplicationViewModelSpec._
@@ -39,55 +36,20 @@ class ApplicationViewModelSpec extends SpecBase {
 
     "when given a valid application" - {
 
-      "when trader's consentToDisclosureOfPersonalData = true" - {
-        val result = ApplicationViewModel(
-          application.modify(_.trader.consentToDisclosureOfPersonalData).setTo(true)
-        )
+      val result = ApplicationViewModel(application)
 
-        "must create rows for the eori details" in {
-          result.eori.rows must be(
-            Seq(
-              SummaryListRow(
-                Key(Text("checkYourAnswers.eori.number.label")),
-                Value(Text(randomString))
-              ),
-              SummaryListRow(
-                Key(Text("checkYourAnswers.eori.name.label")),
-                Value(Text(randomString))
-              ),
-              SummaryListRow(
-                Key(Text("checkYourAnswers.eori.address.label")),
-                Value(
-                  HtmlContent(
-                    s"${randomString}<br>${randomString}<br>${randomString}<br>${randomString}"
-                  )
-                )
-              )
+      "must create rows for the eori details" in {
+        result.eori.rows must be(
+          Seq(
+            SummaryListRow(
+              Key(Text("checkYourAnswers.eori.number.label")),
+              Value(Text(randomString))
             )
           )
-        }
-      }
-
-      "when trader's consentToDisclosureOfPersonalData = false" - {
-        val result = ApplicationViewModel(
-          application.modify(_.trader.consentToDisclosureOfPersonalData).setTo(false)
         )
-
-        "must create rows for the eori details" in {
-          result.eori.rows must be(
-            Seq(
-              SummaryListRow(
-                Key(Text("checkYourAnswers.eori.number.label")),
-                Value(Text(randomString))
-              )
-            )
-          )
-        }
       }
 
       "must create row for the applicant" in {
-        val result = ApplicationViewModel(application)
-
         result.applicant.rows must be(
           Seq(
             SummaryListRow(
@@ -116,11 +78,8 @@ class ApplicationViewModelSpec extends SpecBase {
 object ApplicationViewModelSpec extends Generators {
   val randomString: String = stringsWithMaxLength(8).sample.get
 
-  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
-
   val eoriDetails = TraderDetail(
     eori = randomString,
-    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),


### PR DESCRIPTION
As agreed, the trader private details are now excluded from the application detail page.

<img width="400" alt="Screenshot 2023-04-14 at 12 32 49" src="https://user-images.githubusercontent.com/8526655/232035515-259556d2-a9de-4d5c-b818-caab8fd1ccdf.png">
