### PR TITLE
ARS-787: Remove cancel link from required info page

### DIFF
--- a/app/views/RequiredInformationView.scala.html
+++ b/app/views/RequiredInformationView.scala.html
@@ -23,7 +23,6 @@
     govukErrorSummary: GovukErrorSummary,
     govukCheckboxes: GovukCheckboxes,
     govukButton: GovukButton,
-    cancelApplicationLink: CancelApplicationLink,
     caption: Caption,
     heading: Heading,
     paragraph: Paragraph
@@ -56,6 +55,4 @@
             ButtonViewModel(messages("site.continue"))
         )
     }
-
-    @cancelApplicationLink()
 }


### PR DESCRIPTION
As recommended by the accessibility audit. This removed the cancel link from the requiredInformation page.

<img width="400" alt="Screenshot 2023-04-20 at 12 49 55" src="https://user-images.githubusercontent.com/8526655/233358275-2be66057-e7a5-4d9c-81d2-4e3f1fcf2e47.png">
