### PR TITLE
ARS-789: Use h2 captions for accessibility

### DIFF
--- a/app/views/components/Caption.scala.html
+++ b/app/views/components/Caption.scala.html
@@ -17,5 +17,5 @@
 @this()
 
 @(message: String, captionPrefix: String="caption.prefix")(implicit messages: Messages)
-<p class="govuk-caption-xl"><span class="govuk-visually-hidden">
-    @messages(captionPrefix)</span>@message</p>
+<h2 class="govuk-caption-xl"><span class="govuk-visually-hidden">
+    @messages(captionPrefix)</span>@message</h2>


### PR DESCRIPTION
This uses h2 captions as recommended by the accessibility audit.