### PR TITLE
A11y bug: Global error position fixed

### DIFF
--- a/app/views/CommodityCodeView.scala.html
+++ b/app/views/CommodityCodeView.scala.html
@@ -35,12 +35,12 @@
 
     @formHelper(action = routes.CommodityCodeController.onSubmit(mode)) {
 
-        @caption(messages("commodityCode.caption"))
-        @heading(messages("commodityCode.heading"))
-
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
+
+        @caption(messages("commodityCode.caption"))
+        @heading(messages("commodityCode.heading"))
 
         @govukInput(
             InputViewModel(


### PR DESCRIPTION
- global error moved to top of main section of page

<img width="996" alt="image" src="https://user-images.githubusercontent.com/77161245/233954465-4bf6ee74-9240-4c0e-aa13-dbf319053ea3.png">
