### PR TITLE
ARS-809: Hide back link when js is disabled

### DIFF
--- a/app/views/CancelAreYouSureView.scala.html
+++ b/app/views/CancelAreYouSureView.scala.html
@@ -39,7 +39,7 @@
         )
     }
 
-    <a href = "javascript:history.back()" class="govuk-link" id = "return_to_application">
+    <a href = "javascript:history.back()" class="govuk-link js-visible" id = "return_to_application">
         @messages("cancelAreYouSure.return")
     </a>
 

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -84,9 +84,9 @@
     signOutUrl = if(showBackLink) Some(controllers.auth.routes.AuthController.signOut.url) else None,
     phaseBanner = Some(standardBetaBanner(url = appConfig.feedbackUrl)),
     nonce = CSPNonce.get,
-    backLinkUrl = if(showBackLink) Some("#") else None,
     additionalScriptsBlock = Some(additionalScripts),
     additionalHeadBlock = Some(headBlock),
-    mainContentLayout = mainContentLayout
+    mainContentLayout = mainContentLayout,
+    backLink = if (showBackLink) Option(BackLink.withDefaultText(href = "#", classes = "js-visible")) else None
  )(content)
  


### PR DESCRIPTION
This hides the back link when JS is disabled as recommended by the accessibility audit.