### PR TITLE
ARS-828: Navigate org admin to business contact details

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -484,7 +484,7 @@ class Navigator @Inject() () {
                 isTrader =
                   ApplicationContactDetailsController.onPageLoad(NormalMode, userAnswers.draftId),
                 isEmployee =
-                  ApplicationContactDetailsController.onPageLoad(NormalMode, userAnswers.draftId),
+                  BusinessContactDetailsController.onPageLoad(NormalMode, userAnswers.draftId),
                 isAgent =
                   BusinessContactDetailsController.onPageLoad(NormalMode, userAnswers.draftId)
               )

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -470,7 +470,7 @@ class NavigatorSpec extends SpecBase {
 
         "when OrganisationAdmin" - {
 
-          "navigate to ApplicationContactDetailsController when Yes" in {
+          "navigate to BusinessContactDetailsController when Yes" in {
 
             val userAnswers = userAnswersAsOrgAdmin
               .setFuture(CheckRegisteredDetailsPage, value = true)
@@ -480,7 +480,7 @@ class NavigatorSpec extends SpecBase {
               CheckRegisteredDetailsPage,
               NormalMode,
               userAnswers
-            ) mustBe routes.ApplicationContactDetailsController.onPageLoad(NormalMode, draftId)
+            ) mustBe routes.BusinessContactDetailsController.onPageLoad(NormalMode, draftId)
           }
         }
 


### PR DESCRIPTION
This fixes the failure of the acceptance tests.
Org admin should be navigated to BusinessContactDetailsPage instead of ApplicationContactDetailsPage