### PR TITLE
Revert "ARS-824 Remove return to application button"

### DIFF
--- a/app/views/CancelAreYouSureView.scala.html
+++ b/app/views/CancelAreYouSureView.scala.html
@@ -50,4 +50,8 @@
             ButtonViewModel(messages("cancelAreYouSure.button"))
         )
     }
+
+    <a href = "javascript:history.back()" class="govuk-link js-visible" id = "return_to_application">
+        @messages("cancelAreYouSure.return")
+    </a>
 }


### PR DESCRIPTION
Reverts hmrc/advance-valuation-rulings-frontend#294

Required to revert 824 for a quick deploy