### PR TITLE
ARSSTB-151 Added a PR template for GitHub

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Type of change
+- [ ] Breaking change
+- [ ] Non-breaking change
+- [ ] Cosmetic change
+
+### Description
+Jira link: [Jira title](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-151)
+
+_Provide a short description of the change. For example: what parts of the code changed, is there any new behaviour...etc._
+
+### Attachments or Screenshots
+_Add any screenshots (if relevant) here_


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non breaking change
- [x] Cosmetic change

### Description
Jira link: [ARSSTB-151 Set up gitHub PR description template](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-151)

The idea of this ticket is to provide a template for PR descriptions. After merging this branch, anytime someone creates a pull request, the PR description will be pre-populated from the new template.
See the official GitHub guide for more information on how it works:
[Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
[Basic writing and formatting syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)

### Attachments or Screenshots
_N / A_