### PR TITLE
ARS-963: Update MongoVersion to 1.2.0 (Frontend)

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object AppDependencies {
   import play.core.PlayVersion
 
-  val HmrcMongoPlayVersion              = "1.1.0"
+  val HmrcMongoPlayVersion              = "1.2.0"
   val PlayFrontendHmrcVersion           = "6.8.0-play-28"
   val PlayConditionalFormMappingVersion = "1.12.0-play-28"
   val BootstrapFrontendPlayVersion      = "7.14.0"


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ x] Non-breaking change
- [ ] Cosmetic change

### Description
https://jira.tools.tax.service.gov.uk/browse/ARS-963
update hmrcMongoVersion to 1.2.0 where timeout is 5 seconds
