### PR TITLE
ARS-855 Update removal link id

### DIFF
--- a/app/views/UploadAnotherSupportingDocumentView.scala.html
+++ b/app/views/UploadAnotherSupportingDocumentView.scala.html
@@ -74,7 +74,7 @@
               TableRow(
                 HtmlContent(
                   govukLink(
-                    id = attachment.file.reference,
+                    id = "remove-link-" + i,
                     text = messages("site.remove"),
                     call = controllers.routes.RemoveSupportingDocumentController.onPageLoad(mode, draftId, Index(i)),
                     newTab = false

--- a/app/views/UploadAnotherSupportingDocumentView.scala.html
+++ b/app/views/UploadAnotherSupportingDocumentView.scala.html
@@ -74,7 +74,7 @@
               TableRow(
                 HtmlContent(
                   govukLink(
-                    id = "remove-link-" + i,
+                    id = "remove-file-" + i,
                     text = messages("site.remove"),
                     call = controllers.routes.RemoveSupportingDocumentController.onPageLoad(mode, draftId, Index(i)),
                     newTab = false


### PR DESCRIPTION
### Type of change
- [X] Non-breaking change

Just updating the link identifier to ease acceptance testing.  Required change for the following tests:  https://github.com/hmrc/advance-valuation-rulings-acceptance/pull/65
