### PR TITLE
ARS-950 Handle incomplete file upload journeys

### DIFF
--- a/app/controllers/IsThisFileConfidentialController.scala
+++ b/app/controllers/IsThisFileConfidentialController.scala
@@ -29,7 +29,7 @@ import actions.{DataRequiredAction, DataRetrievalActionProvider, IdentifierActio
 import forms.IsThisFileConfidentialFormProvider
 import models._
 import navigation.Navigator
-import pages.{IsThisFileConfidentialPage, UploadSupportingDocumentPage}
+import pages._
 import queries.AllDocuments
 import services.UserAnswersService
 import views.html.IsThisFileConfidentialView
@@ -60,7 +60,7 @@ class IsThisFileConfidentialController @Inject() (
 
         val validIndex        = !(index.position > attachments || index.position >= maxFiles)
         lazy val isSuccessful =
-          UploadSupportingDocumentPage(index).get().map(_.isSuccessful).getOrElse(false)
+          UploadedFilePage(index).get().map(_.isSuccessful).getOrElse(false)
 
         (validIndex, isSuccessful) match {
           case (true, true)          =>

--- a/app/controllers/IsThisFileConfidentialController.scala
+++ b/app/controllers/IsThisFileConfidentialController.scala
@@ -98,7 +98,7 @@ class IsThisFileConfidentialController @Inject() (
                       routes.UploadSupportingDocumentsController
                         .onPageLoad(mode, request.userAnswers.draftId, None, None)
                     )
-                  ) // TODO: this could go to uploaded documents instead
+                  )
               }
           )
     }

--- a/app/controllers/IsThisFileConfidentialController.scala
+++ b/app/controllers/IsThisFileConfidentialController.scala
@@ -49,56 +49,57 @@ class IsThisFileConfidentialController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  private val maxFiles = configuration.get[Int]("upscan.maxFiles")
-
   private val form = formProvider()
 
-  def onPageLoad(index: Index, mode: Mode, draftId: DraftId): Action[AnyContent] =
+  def onPageLoad(mode: Mode, draftId: DraftId): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
-        val attachments = AllDocuments.get().map(_.size).getOrElse(0)
-
-        val validIndex        = !(index.position > attachments || index.position >= maxFiles)
         lazy val isSuccessful =
-          UploadedFilePage(index).get().map(_.isSuccessful).getOrElse(false)
+          UploadSupportingDocumentPage.get().map(_.isSuccessful).getOrElse(false)
 
-        (validIndex, isSuccessful) match {
-          case (true, true)          =>
-            val preparedForm = IsThisFileConfidentialPage(index).fill(form)
-            Ok(view(preparedForm, index, mode, draftId))
-          case (true, false)         =>
+        isSuccessful match {
+          case true  =>
+            val preparedForm = IsThisFileConfidentialPage.fill(form)
+            Ok(view(preparedForm, mode, draftId))
+          case false =>
             Redirect(
               routes.UploadSupportingDocumentsController
-                .onPageLoad(index, mode, request.userAnswers.draftId, None, None)
+                .onPageLoad(mode, request.userAnswers.draftId, None, None)
             )
-          case (false, true | false) => NotFound
         }
     }
 
-  def onSubmit(index: Index, mode: Mode, draftId: DraftId): Action[AnyContent] =
+  def onSubmit(mode: Mode, draftId: DraftId): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData).async {
       implicit request =>
-        val attachments = AllDocuments.get().map(_.size).getOrElse(0)
+        form
+          .bindFromRequest()
+          .fold(
+            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            value =>
+              UploadSupportingDocumentPage.get() match {
+                case Some(file: UploadedFile.Success) =>
+                  val allDocuments = AllDocuments.get().getOrElse(List.empty[DraftAttachment])
+                  val draft        = DraftAttachment(file, Some(value))
+                  val documents    = allDocuments :+ draft
 
-        if (index.position > attachments || index.position >= maxFiles) {
-          Future.successful(NotFound)
-        } else {
+                  for {
+                    ua <- AllDocuments.set(documents)
+                    ua <- ua.removeFuture(UploadSupportingDocumentPage)
+                    ua <- ua.removeFuture(IsThisFileConfidentialPage)
+                    _  <- userAnswersService.set(ua)
+                  } yield Redirect(
+                    navigator.nextPage(IsThisFileConfidentialPage, mode, ua)
+                  )
 
-          form
-            .bindFromRequest()
-            .fold(
-              formWithErrors =>
-                Future.successful(BadRequest(view(formWithErrors, index, mode, draftId))),
-              value =>
-                for {
-                  updatedAnswers <-
-                    Future
-                      .fromTry(request.userAnswers.set(IsThisFileConfidentialPage(index), value))
-                  _              <- userAnswersService.set(updatedAnswers)
-                } yield Redirect(
-                  navigator.nextPage(IsThisFileConfidentialPage(index), mode, updatedAnswers)
-                )
-            )
-        }
+                case _ =>
+                  Future.successful(
+                    Redirect(
+                      routes.UploadSupportingDocumentsController
+                        .onPageLoad(mode, request.userAnswers.draftId, None, None)
+                    )
+                  ) // TODO: this could go to uploaded documents instead
+              }
+          )
     }
 }

--- a/app/controllers/RemoveSupportingDocumentController.scala
+++ b/app/controllers/RemoveSupportingDocumentController.scala
@@ -30,7 +30,7 @@ import controllers.actions._
 import forms.RemoveSupportingDocumentFormProvider
 import models.{DraftId, Index, Mode, UserAnswers}
 import navigation.Navigator
-import pages.{RemoveSupportingDocumentPage, UploadSupportingDocumentPage}
+import pages._
 import queries.{AllDocuments, DraftAttachmentQuery}
 import services.UserAnswersService
 import views.html.RemoveSupportingDocumentView
@@ -55,7 +55,7 @@ class RemoveSupportingDocumentController @Inject() (
   def onPageLoad(mode: Mode, draftId: DraftId, index: Index): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
-        UploadSupportingDocumentPage(index).get().flatMap(_.fileName) match {
+        UploadedFilePage(index).get().flatMap(_.fileName) match {
           case Some(fileName) =>
             Ok(view(form, mode, draftId, index, fileName))
           case None           =>
@@ -67,7 +67,7 @@ class RemoveSupportingDocumentController @Inject() (
     (identify andThen getData(draftId) andThen requireData).async {
       implicit request =>
         val urlAndFileName = for {
-          file     <- UploadSupportingDocumentPage(index).get()
+          file     <- UploadedFilePage(index).get()
           url      <- file.fileUrl
           fileName <- file.fileName
         } yield (url, fileName)

--- a/app/controllers/RemoveSupportingDocumentController.scala
+++ b/app/controllers/RemoveSupportingDocumentController.scala
@@ -31,7 +31,7 @@ import forms.RemoveSupportingDocumentFormProvider
 import models.{DraftId, Index, Mode, UserAnswers}
 import navigation.Navigator
 import pages._
-import queries.{AllDocuments, DraftAttachmentQuery}
+import queries._
 import services.UserAnswersService
 import views.html.RemoveSupportingDocumentView
 
@@ -55,7 +55,7 @@ class RemoveSupportingDocumentController @Inject() (
   def onPageLoad(mode: Mode, draftId: DraftId, index: Index): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
-        UploadedFilePage(index).get().flatMap(_.fileName) match {
+        DraftAttachmentAt(index).get().flatMap(_.file.fileName) match {
           case Some(fileName) =>
             Ok(view(form, mode, draftId, index, fileName))
           case None           =>
@@ -67,9 +67,9 @@ class RemoveSupportingDocumentController @Inject() (
     (identify andThen getData(draftId) andThen requireData).async {
       implicit request =>
         val urlAndFileName = for {
-          file     <- UploadedFilePage(index).get()
-          url      <- file.fileUrl
-          fileName <- file.fileName
+          draft    <- DraftAttachmentAt(index).get()
+          url      <- draft.file.fileUrl
+          fileName <- draft.file.fileName
         } yield (url, fileName)
 
         urlAndFileName match {

--- a/app/controllers/UploadSupportingDocumentsController.scala
+++ b/app/controllers/UploadSupportingDocumentsController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import controllers.actions.{DataRequiredAction, DataRetrievalActionProvider, IdentifierAction}
 import models._
 import navigation.Navigator
-import pages.UploadSupportingDocumentPage
+import pages._
 import queries.AllDocuments
 import services.fileupload.FileService
 import views.html.UploadSupportingDocumentsView
@@ -67,7 +67,7 @@ class UploadSupportingDocumentsController @Inject() (
           Future.successful(NotFound)
         } else {
 
-          val file = answers.get(UploadSupportingDocumentPage(index))
+          val file = answers.get(UploadedFilePage(index))
 
           file
             .map {
@@ -161,7 +161,7 @@ class UploadSupportingDocumentsController @Inject() (
   private def continue(index: Index, mode: Mode, answers: UserAnswers): Future[Result] =
     Future.successful(
       Redirect(
-        navigator.nextPage(UploadSupportingDocumentPage(index), mode, answers)
+        navigator.nextPage(UploadedFilePage(index), mode, answers)
       )
     )
 

--- a/app/controllers/callback/UploadCallbackController.scala
+++ b/app/controllers/callback/UploadCallbackController.scala
@@ -24,7 +24,7 @@ import scala.concurrent.ExecutionContext
 import play.api.mvc.MessagesControllerComponents
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
-import models.{DraftId, Index, UploadedFile}
+import models.{DraftId, UploadedFile}
 import services.fileupload.FileService
 
 @Singleton
@@ -34,7 +34,7 @@ class UploadCallbackController @Inject() (
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController {
 
-  def callback(draftId: DraftId, index: Index) = Action.async(parse.json[UploadedFile]) {
-    implicit request => fileService.update(draftId, index, request.body).as(Ok)
+  def callback(draftId: DraftId) = Action.async(parse.json[UploadedFile]) {
+    implicit request => fileService.update(draftId, request.body).as(Ok)
   }
 }

--- a/app/models/requests/AttachmentRequest.scala
+++ b/app/models/requests/AttachmentRequest.scala
@@ -68,5 +68,5 @@ object AttachmentRequest {
     }
 
   private def getFilePrivacy(answers: UserAnswers, index: Int): ValidatedNel[Page, Boolean] =
-    answers.validated(IsThisFileConfidentialPage(Index(index)))
+    answers.validated(WasThisFileConfidentialPage(Index(index)))
 }

--- a/app/models/requests/AttachmentRequest.scala
+++ b/app/models/requests/AttachmentRequest.scala
@@ -22,7 +22,7 @@ import cats.implicits._
 import play.api.libs.json.{Json, OFormat}
 
 import models.{Index, UploadedFile, UserAnswers}
-import pages.{DoYouWantToUploadDocumentsPage, IsThisFileConfidentialPage, Page, UploadSupportingDocumentPage}
+import pages._
 import queries.AllDocuments
 
 final case class AttachmentRequest(
@@ -41,7 +41,7 @@ object AttachmentRequest {
   def apply(answers: UserAnswers): ValidatedNel[Page, Seq[AttachmentRequest]] =
     answers.validated(DoYouWantToUploadDocumentsPage).andThen {
       case true  =>
-        answers.get(AllDocuments).toValidNel(UploadSupportingDocumentPage(Index(0))).andThen {
+        answers.get(AllDocuments).toValidNel(UploadedFilePage(Index(0))).andThen {
           _.indices.toList.traverse {
             i =>
               (getFile(answers, i), getFilePrivacy(answers, i)).mapN {
@@ -62,9 +62,9 @@ object AttachmentRequest {
     }
 
   private def getFile(answers: UserAnswers, index: Int): ValidatedNel[Page, UploadedFile.Success] =
-    answers.validated(UploadSupportingDocumentPage(Index(index))).andThen {
+    answers.validated(UploadedFilePage(Index(index))).andThen {
       case file: UploadedFile.Success => file.validNel
-      case _                          => UploadSupportingDocumentPage(Index(index)).invalidNel
+      case _                          => UploadedFilePage(Index(index)).invalidNel
     }
 
   private def getFilePrivacy(answers: UserAnswers, index: Int): ValidatedNel[Page, Boolean] =

--- a/app/navigation/CheckModeNavigator.scala
+++ b/app/navigation/CheckModeNavigator.scala
@@ -323,7 +323,7 @@ object CheckModeNavigator {
         haveBeenSubjectToLegalChallenges(userAnswers)
       case HasCommodityCodePage                         => hasCommodityCode(userAnswers)
       case DoYouWantToUploadDocumentsPage               => doYouWantToUploadDocuments(userAnswers)
-      case UploadSupportingDocumentPage(index)          => uploadSupportingDocumentPage(index)(userAnswers)
+      case UploadedFilePage(index)          => uploadSupportingDocumentPage(index)(userAnswers)
       case IsThisFileConfidentialPage(index)            => isThisFileConfidential(index)(userAnswers)
       case UploadAnotherSupportingDocumentPage          => uploadAnotherSupportingDocument(userAnswers)
       case WhatIsYourRoleAsImporterPage                 => whatIsYourRoleAsImporter(userAnswers)

--- a/app/navigation/CheckModeNavigator.scala
+++ b/app/navigation/CheckModeNavigator.scala
@@ -99,20 +99,17 @@ object CheckModeNavigator {
       case None        => DoYouWantToUploadDocumentsController.onPageLoad(CheckMode, userAnswers.draftId)
       case Some(true)  =>
         UploadSupportingDocumentsController
-          .onPageLoad(Index(0), CheckMode, userAnswers.draftId, None, None)
+          .onPageLoad(CheckMode, userAnswers.draftId, None, None)
       case Some(false) => navigateWithAuthUserType(userAnswers)
     }
 
-  private def uploadSupportingDocumentPage(
-    index: Index
-  )(userAnswers: UserAnswers): Call =
+  private def uploadSupportingDocumentPage(userAnswers: UserAnswers): Call =
     IsThisFileConfidentialController.onPageLoad(
-      index,
       CheckMode,
       userAnswers.draftId
     )
 
-  private def isThisFileConfidential(index: Index)(userAnswers: UserAnswers): Call =
+  private def isThisFileConfidential(userAnswers: UserAnswers): Call =
     UploadAnotherSupportingDocumentController.onPageLoad(CheckMode, userAnswers.draftId)
 
   private def uploadAnotherSupportingDocument(userAnswers: UserAnswers): Call =
@@ -120,9 +117,7 @@ object CheckModeNavigator {
       .get(UploadAnotherSupportingDocumentPage)
       .map {
         case true  =>
-          val nextIndex = userAnswers.get(AllDocuments).map(_.size).getOrElse(0)
           UploadSupportingDocumentsController.onPageLoad(
-            Index(nextIndex),
             CheckMode,
             userAnswers.draftId,
             None,
@@ -323,8 +318,8 @@ object CheckModeNavigator {
         haveBeenSubjectToLegalChallenges(userAnswers)
       case HasCommodityCodePage                         => hasCommodityCode(userAnswers)
       case DoYouWantToUploadDocumentsPage               => doYouWantToUploadDocuments(userAnswers)
-      case UploadedFilePage(index)          => uploadSupportingDocumentPage(index)(userAnswers)
-      case IsThisFileConfidentialPage(index)            => isThisFileConfidential(index)(userAnswers)
+      case UploadSupportingDocumentPage                 => uploadSupportingDocumentPage(userAnswers)
+      case IsThisFileConfidentialPage                   => isThisFileConfidential(userAnswers)
       case UploadAnotherSupportingDocumentPage          => uploadAnotherSupportingDocument(userAnswers)
       case WhatIsYourRoleAsImporterPage                 => whatIsYourRoleAsImporter(userAnswers)
       case RemoveSupportingDocumentPage(_)              => removeSupportingDocumentPage(userAnswers)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -356,12 +356,12 @@ class Navigator @Inject() () {
       case Some(true)  =>
         ConfidentialInformationController.onPageLoad(NormalMode, userAnswers.draftId)
       case Some(false) =>
-        val numberOfDocuments = userAnswers.get(AllDocuments).getOrElse(Seq.empty).size
-        if (numberOfDocuments > 0) {
+        val documents = userAnswers.getOrElse(AllDocuments, List.empty)
+        if (documents.isEmpty) {
+          DoYouWantToUploadDocumentsController.onPageLoad(NormalMode, userAnswers.draftId)
+        } else {
           UploadAnotherSupportingDocumentController
             .onPageLoad(NormalMode, userAnswers.draftId)
-        } else {
-          DoYouWantToUploadDocumentsController.onPageLoad(NormalMode, userAnswers.draftId)
         }
     }
 
@@ -369,12 +369,12 @@ class Navigator @Inject() () {
     userAnswers.get(ConfidentialInformationPage) match {
       case None    => ConfidentialInformationController.onPageLoad(NormalMode, userAnswers.draftId)
       case Some(_) =>
-        val numberOfDocuments = userAnswers.get(AllDocuments).getOrElse(Seq.empty).size
-        if (numberOfDocuments > 0) {
+        val documents = userAnswers.getOrElse(AllDocuments, List.empty)
+        if (documents.isEmpty) {
+          DoYouWantToUploadDocumentsController.onPageLoad(NormalMode, userAnswers.draftId)
+        } else {
           UploadAnotherSupportingDocumentController
             .onPageLoad(NormalMode, userAnswers.draftId)
-        } else {
-          DoYouWantToUploadDocumentsController.onPageLoad(NormalMode, userAnswers.draftId)
         }
     }
 

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -59,7 +59,7 @@ class Navigator @Inject() () {
     case BusinessContactDetailsPage                       => businessContactDetailsPage
     case AgentCompanyDetailsPage                          => agentCompanyDetailsPage
     case DoYouWantToUploadDocumentsPage                   => doYouWantToUploadDocumentsPage
-    case UploadSupportingDocumentPage(index)              => uploadSupportingDocumentPage(index)
+    case UploadedFilePage(index)              => uploadSupportingDocumentPage(index)
     case IsThisFileConfidentialPage(index)                => isThisFileConfidentialPage(index)
     case UploadAnotherSupportingDocumentPage              => uploadAnotherSupportingDocumentPage
     case RemoveSupportingDocumentPage(_)                  => removeSupportingDocumentPage

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -59,8 +59,8 @@ class Navigator @Inject() () {
     case BusinessContactDetailsPage                       => businessContactDetailsPage
     case AgentCompanyDetailsPage                          => agentCompanyDetailsPage
     case DoYouWantToUploadDocumentsPage                   => doYouWantToUploadDocumentsPage
-    case UploadedFilePage(index)              => uploadSupportingDocumentPage(index)
-    case IsThisFileConfidentialPage(index)                => isThisFileConfidentialPage(index)
+    case UploadSupportingDocumentPage                     => uploadSupportingDocumentPage
+    case IsThisFileConfidentialPage                       => isThisFileConfidentialPage
     case UploadAnotherSupportingDocumentPage              => uploadAnotherSupportingDocumentPage
     case RemoveSupportingDocumentPage(_)                  => removeSupportingDocumentPage
     case WhyComputedValuePage                             => whyComputedValuePage
@@ -383,7 +383,7 @@ class Navigator @Inject() () {
       case None        => DoYouWantToUploadDocumentsController.onPageLoad(NormalMode, userAnswers.draftId)
       case Some(true)  =>
         UploadSupportingDocumentsController
-          .onPageLoad(Index(0), NormalMode, userAnswers.draftId, None, None)
+          .onPageLoad(NormalMode, userAnswers.draftId, None, None)
       case Some(false) =>
         userAnswers.get(AccountHomePage) match {
           case None               => UnauthorisedController.onPageLoad
@@ -396,16 +396,15 @@ class Navigator @Inject() () {
         }
     }
 
-  private def uploadSupportingDocumentPage(index: Index)(
+  private def uploadSupportingDocumentPage(
     userAnswers: UserAnswers
   ): Call =
     IsThisFileConfidentialController.onPageLoad(
-      index,
       NormalMode,
       userAnswers.draftId
     )
 
-  private def isThisFileConfidentialPage(index: Index)(
+  private def isThisFileConfidentialPage(
     userAnswers: UserAnswers
   ): Call =
     UploadAnotherSupportingDocumentController
@@ -418,9 +417,7 @@ class Navigator @Inject() () {
       .get(UploadAnotherSupportingDocumentPage)
       .map {
         case true  =>
-          val nextIndex = userAnswers.get(AllDocuments).map(_.size).getOrElse(0)
           UploadSupportingDocumentsController.onPageLoad(
-            Index(nextIndex),
             NormalMode,
             userAnswers.draftId,
             None,

--- a/app/pages/IsThisFileConfidentialPage.scala
+++ b/app/pages/IsThisFileConfidentialPage.scala
@@ -20,7 +20,14 @@ import play.api.libs.json.JsPath
 
 import models.Index
 
-final case class IsThisFileConfidentialPage(index: Index) extends QuestionPage[Boolean] {
+final case object IsThisFileConfidentialPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString()
+
+  override def toString: String = "isThisFileConfidential"
+}
+
+final case class WasThisFileConfidentialPage(index: Index) extends QuestionPage[Boolean] {
 
   override def path: JsPath = JsPath \ "supportingDocuments" \ index.position \ toString
 

--- a/app/pages/IsThisFileConfidentialPage.scala
+++ b/app/pages/IsThisFileConfidentialPage.scala
@@ -18,18 +18,9 @@ package pages
 
 import play.api.libs.json.JsPath
 
-import models.Index
-
-final case object IsThisFileConfidentialPage extends QuestionPage[Boolean] {
+case object IsThisFileConfidentialPage extends QuestionPage[Boolean] {
 
   override def path: JsPath = JsPath \ toString()
-
-  override def toString: String = "isThisFileConfidential"
-}
-
-final case class WasThisFileConfidentialPage(index: Index) extends QuestionPage[Boolean] {
-
-  override def path: JsPath = JsPath \ "supportingDocuments" \ index.position \ toString
 
   override def toString: String = "isThisFileConfidential"
 }

--- a/app/pages/UploadSupportingDocumentPage.scala
+++ b/app/pages/UploadSupportingDocumentPage.scala
@@ -20,7 +20,15 @@ import play.api.libs.json.JsPath
 
 import models.{Index, UploadedFile}
 
-final case class UploadSupportingDocumentPage(index: Index) extends QuestionPage[UploadedFile] {
+case object UploadSupportingDocumentPage extends QuestionPage[UploadedFile] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "uploadSupportingDocumentPage"
+}
+
+// Duplicate of the old UploadSupportingDocumentPage
+final case class UploadedFilePage(index: Index) extends QuestionPage[UploadedFile] {
 
   override def path: JsPath = JsPath \ "supportingDocuments" \ index.position \ "file"
 

--- a/app/pages/UploadSupportingDocumentPage.scala
+++ b/app/pages/UploadSupportingDocumentPage.scala
@@ -18,19 +18,11 @@ package pages
 
 import play.api.libs.json.JsPath
 
-import models.{Index, UploadedFile}
+import models.UploadedFile
 
 case object UploadSupportingDocumentPage extends QuestionPage[UploadedFile] {
 
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "uploadSupportingDocumentPage"
-}
-
-// Duplicate of the old UploadSupportingDocumentPage
-final case class UploadedFilePage(index: Index) extends QuestionPage[UploadedFile] {
-
-  override def path: JsPath = JsPath \ "supportingDocuments" \ index.position \ "file"
-
-  override def toString: String = "file"
 }

--- a/app/queries/AllDocuments.scala
+++ b/app/queries/AllDocuments.scala
@@ -17,8 +17,13 @@
 package queries
 import play.api.libs.json.{__, JsPath}
 
-import models.DraftAttachment
+import models.{DraftAttachment, Index}
+import pages.QuestionPage
 
-case object AllDocuments extends Modifiable[List[DraftAttachment]] {
+case object AllDocuments extends QuestionPage[List[DraftAttachment]] {
   override def path: JsPath = __ \ "supportingDocuments"
+}
+
+final case class DraftAttachmentAt(index: Index) extends QuestionPage[DraftAttachment] {
+  override def path: JsPath = JsPath \ "supportingDocuments" \ index.position
 }

--- a/app/services/fileupload/FileService.scala
+++ b/app/services/fileupload/FileService.scala
@@ -30,9 +30,9 @@ import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 
 import config.Service
 import connectors.UpscanConnector
-import models.{Done, DraftId, Index, Mode, UploadedFile, UserAnswers}
+import models.{Done, DraftId, Mode, UploadedFile, UserAnswers}
 import models.upscan.{UpscanInitiateRequest, UpscanInitiateResponse}
-import pages.{UploadedFilePage, UploadSupportingDocumentPage}
+import pages.UploadSupportingDocumentPage
 import queries.AllDocuments
 import services.UserAnswersService
 import services.fileupload.FileService.NoUserAnswersFoundException
@@ -54,19 +54,19 @@ class FileService @Inject() (
 
   private implicit val hc: HeaderCarrier = HeaderCarrier()
 
-  def initiate(draftId: DraftId, mode: Mode, index: Index)(implicit
+  def initiate(draftId: DraftId, mode: Mode)(implicit
     hc: HeaderCarrier
   ): Future[UpscanInitiateResponse] = {
 
     val redirectPath =
       controllers.routes.UploadSupportingDocumentsController
-        .onPageLoad(index, mode, draftId, None, None)
+        .onPageLoad(mode, draftId, None, None)
         .url
     val redirectUrl  = s"$host$redirectPath"
 
     val request = UpscanInitiateRequest(
       callbackUrl =
-        s"$callbackBaseUrl${controllers.callback.routes.UploadCallbackController.callback(draftId, index).url}",
+        s"$callbackBaseUrl${controllers.callback.routes.UploadCallbackController.callback(draftId).url}",
       successRedirect = redirectUrl,
       errorRedirect = redirectUrl,
       minimumFileSize = minimumFileSize,
@@ -76,35 +76,30 @@ class FileService @Inject() (
     for {
       response       <- upscanConnector.initiate(request)
       answers        <- getUserAnswers(draftId)
-      updatedAnswers <- Future.fromTry(
-                          answers.set(
-                            UploadedFilePage(index),
-                            UploadedFile.Initiated(response.reference)
-                          )
-                        )
+      updatedAnswers <-
+        answers.setFuture(
+          UploadSupportingDocumentPage,
+          UploadedFile.Initiated(response.reference)
+        )
       _              <- userAnswersService.set(updatedAnswers)
     } yield response
   }
 
-  def update(draftId: DraftId, index: Index, file: UploadedFile): Future[Done] =
+  def update(draftId: DraftId, file: UploadedFile): Future[Done] =
     for {
       answers        <- getUserAnswersInternal(draftId)
-      updatedFile    <- processFile(answers, index, file)
-      updatedAnswers <-
-        Future.fromTry(answers.set(UploadedFilePage(index), updatedFile))
+      updatedFile    <- processFile(answers, file)
+      updatedAnswers <- answers.setFuture(UploadSupportingDocumentPage, updatedFile)
       _              <- userAnswersService.setInternal(updatedAnswers)
     } yield Done
 
   private def processFile(
     answers: UserAnswers,
-    index: Index,
     file: UploadedFile
   ): Future[UploadedFile] =
     file match {
       case file: UploadedFile.Success =>
-        val documents      = answers.get(AllDocuments).getOrElse(Seq.empty)
-        val otherDocuments =
-          documents.patch(index.position, Seq.empty, 1)
+        val otherDocuments = answers.get(AllDocuments).getOrElse(Seq.empty)
 
         if (otherDocuments.flatMap(_.file.fileName).contains(file.uploadDetails.fileName)) {
 

--- a/app/services/fileupload/FileService.scala
+++ b/app/services/fileupload/FileService.scala
@@ -32,7 +32,7 @@ import config.Service
 import connectors.UpscanConnector
 import models.{Done, DraftId, Index, Mode, UploadedFile, UserAnswers}
 import models.upscan.{UpscanInitiateRequest, UpscanInitiateResponse}
-import pages.UploadSupportingDocumentPage
+import pages.{UploadedFilePage, UploadSupportingDocumentPage}
 import queries.AllDocuments
 import services.UserAnswersService
 import services.fileupload.FileService.NoUserAnswersFoundException
@@ -78,7 +78,7 @@ class FileService @Inject() (
       answers        <- getUserAnswers(draftId)
       updatedAnswers <- Future.fromTry(
                           answers.set(
-                            UploadSupportingDocumentPage(index),
+                            UploadedFilePage(index),
                             UploadedFile.Initiated(response.reference)
                           )
                         )
@@ -91,7 +91,7 @@ class FileService @Inject() (
       answers        <- getUserAnswersInternal(draftId)
       updatedFile    <- processFile(answers, index, file)
       updatedAnswers <-
-        Future.fromTry(answers.set(UploadSupportingDocumentPage(index), updatedFile))
+        Future.fromTry(answers.set(UploadedFilePage(index), updatedFile))
       _              <- userAnswersService.setInternal(updatedAnswers)
     } yield Done
 

--- a/app/views/IsThisFileConfidentialView.scala.html
+++ b/app/views/IsThisFileConfidentialView.scala.html
@@ -29,7 +29,7 @@
     govukButton: GovukButton
 )
 
-@(form: Form[_], index: Index, mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("isThisFileConfidential.title")), draftId = Some(draftId)) {
 
@@ -44,7 +44,7 @@
     @paragraph(Html(messages("isThisFileConfidential.para.2")))
 
 
-    @formHelper(action = routes.IsThisFileConfidentialController.onSubmit(index, mode, draftId), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.IsThisFileConfidentialController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
         
         @govukRadios(
             RadiosViewModel.yesNo(

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -83,13 +83,13 @@ POST       /:draftId/add-supporting-documents                                   
 GET        /:draftId/change-add-supporting-documents                                controllers.DoYouWantToUploadDocumentsController.onPageLoad(mode: Mode = CheckMode, draftId: DraftId)
 POST       /:draftId/change-add-supporting-documents                                controllers.DoYouWantToUploadDocumentsController.onSubmit(mode: Mode = CheckMode, draftId: DraftId)
 
-GET        /:draftId/supporting-documents/:index/upload                            controllers.UploadSupportingDocumentsController.onPageLoad(index: Index, mode: Mode = NormalMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
-GET        /:draftId/supporting-documents/:index/change-upload                     controllers.UploadSupportingDocumentsController.onPageLoad(index: Index, mode: Mode = CheckMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
+GET        /:draftId/supporting-documents/upload                                  controllers.UploadSupportingDocumentsController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
+GET        /:draftId/supporting-documents/change-upload                           controllers.UploadSupportingDocumentsController.onPageLoad(mode: Mode = CheckMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
 
-GET        /:draftId/supporting-documents/:index/mark-confidential                 controllers.IsThisFileConfidentialController.onPageLoad(index: Index, mode: Mode = NormalMode, draftId: DraftId)
-POST       /:draftId/supporting-documents/:index/mark-confidential                 controllers.IsThisFileConfidentialController.onSubmit(index: Index, mode: Mode = NormalMode, draftId: DraftId)
-GET        /:draftId/supporting-documents/:index/change-mark-confidential          controllers.IsThisFileConfidentialController.onPageLoad(index: Index, mode: Mode = CheckMode, draftId: DraftId)
-POST       /:draftId/supporting-documents/:index/change-mark-confidential          controllers.IsThisFileConfidentialController.onSubmit(index: Index, mode: Mode = CheckMode, draftId: DraftId)
+GET        /:draftId/supporting-documents/mark-confidential                       controllers.IsThisFileConfidentialController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId)
+POST       /:draftId/supporting-documents/mark-confidential                       controllers.IsThisFileConfidentialController.onSubmit(mode: Mode = NormalMode, draftId: DraftId)
+GET        /:draftId/supporting-documents/change-mark-confidential                controllers.IsThisFileConfidentialController.onPageLoad(mode: Mode = CheckMode, draftId: DraftId)
+POST       /:draftId/supporting-documents/change-mark-confidential                controllers.IsThisFileConfidentialController.onSubmit(mode: Mode = CheckMode, draftId: DraftId)
 
 GET        /:draftId/supporting-documents/uploaded                                 controllers.UploadAnotherSupportingDocumentController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId)
 POST       /:draftId/supporting-documents/uploaded                                 controllers.UploadAnotherSupportingDocumentController.onSubmit(mode: Mode = NormalMode, draftId: DraftId)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -6,7 +6,7 @@ GET        /admin/metrics                               @com.kenshoo.play.metric
 
 # upload file notification callback
 + nocsrf
-POST       /upscan-callback/:draftId/:index          controllers.callback.UploadCallbackController.callback(draftId: DraftId, index: Index)
+POST       /upscan-callback/:draftId                    controllers.callback.UploadCallbackController.callback(draftId: DraftId)
 
 + nocsrf
 GET        /attachments/*location                       controllers.callback.AttachmentsController.get(location)

--- a/test-utils/generators/PageGenerators.scala
+++ b/test-utils/generators/PageGenerators.scala
@@ -127,7 +127,7 @@ trait PageGenerators {
     Arbitrary(UploadAnotherSupportingDocumentPage)
 
   implicit lazy val arbitraryIsThisFileConfidentialPage: Arbitrary[IsThisFileConfidentialPage] =
-    Arbitrary(IsThisFileConfidentialPage(Index(0)))
+    Arbitrary(WasThisFileConfidentialPage(Index(0)))
 
   implicit lazy val arbitraryDoYouWantToUploadDocumentsPage
     : Arbitrary[DoYouWantToUploadDocumentsPage.type] =

--- a/test-utils/generators/PageGenerators.scala
+++ b/test-utils/generators/PageGenerators.scala
@@ -16,7 +16,6 @@
 
 package generators
 
-import models.Index
 import org.scalacheck.Arbitrary
 import pages._
 
@@ -126,8 +125,9 @@ trait PageGenerators {
     : Arbitrary[UploadAnotherSupportingDocumentPage.type] =
     Arbitrary(UploadAnotherSupportingDocumentPage)
 
-  implicit lazy val arbitraryIsThisFileConfidentialPage: Arbitrary[IsThisFileConfidentialPage] =
-    Arbitrary(WasThisFileConfidentialPage(Index(0)))
+  implicit lazy val arbitraryIsThisFileConfidentialPage
+    : Arbitrary[IsThisFileConfidentialPage.type] =
+    Arbitrary(IsThisFileConfidentialPage)
 
   implicit lazy val arbitraryDoYouWantToUploadDocumentsPage
     : Arbitrary[DoYouWantToUploadDocumentsPage.type] =

--- a/test-utils/generators/UserAnswersEntryGenerators.scala
+++ b/test-utils/generators/UserAnswersEntryGenerators.scala
@@ -278,10 +278,10 @@ trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
     }
 
   implicit lazy val arbitraryIsThisFileConfidentialUserAnswersEntry
-    : Arbitrary[(IsThisFileConfidentialPage, JsValue)] =
+    : Arbitrary[(IsThisFileConfidentialPage.type, JsValue)] =
     Arbitrary {
       for {
-        page  <- arbitrary[IsThisFileConfidentialPage]
+        page  <- arbitrary[IsThisFileConfidentialPage.type]
         value <- arbitrary[Boolean].map(Json.toJson(_))
       } yield (page, value)
     }

--- a/test-utils/generators/UserAnswersGenerator.scala
+++ b/test-utils/generators/UserAnswersGenerator.scala
@@ -57,7 +57,7 @@ trait UserAnswersGenerator extends TryValues {
       arbitrary[(WhyComputedValuePage.type, JsValue)] ::
       arbitrary[(ExplainReasonComputedValuePage.type, JsValue)] ::
       arbitrary[(UploadAnotherSupportingDocumentPage.type, JsValue)] ::
-      arbitrary[(IsThisFileConfidentialPage, JsValue)] ::
+      arbitrary[(IsThisFileConfidentialPage.type, JsValue)] ::
       arbitrary[(DoYouWantToUploadDocumentsPage.type, JsValue)] ::
       arbitrary[(ApplicationContactDetailsPage.type, JsValue)] ::
       arbitrary[(CheckRegisteredDetailsPage.type, JsValue)] ::

--- a/test/controllers/IsThisFileConfidentialControllerSpec.scala
+++ b/test/controllers/IsThisFileConfidentialControllerSpec.scala
@@ -32,7 +32,7 @@ import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{IsThisFileConfidentialPage, UploadSupportingDocumentPage}
+import pages._
 import services.UserAnswersService
 import views.html.IsThisFileConfidentialView
 
@@ -60,7 +60,7 @@ class IsThisFileConfidentialControllerSpec extends SpecBase with MockitoSugar {
 
   private val userAnswers =
     userAnswersAsIndividualTrader
-      .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+      .set(UploadedFilePage(Index(0)), successfulFile)
       .success
       .value
 
@@ -223,7 +223,7 @@ class IsThisFileConfidentialControllerSpec extends SpecBase with MockitoSugar {
       )
       val answers     =
         userAnswersAsIndividualTrader
-          .set(UploadSupportingDocumentPage(Index(0)), failedFile)
+          .set(UploadedFilePage(Index(0)), failedFile)
           .success
           .value
       val application = applicationBuilder(userAnswers = Some(answers)).build()

--- a/test/controllers/IsThisFileConfidentialControllerSpec.scala
+++ b/test/controllers/IsThisFileConfidentialControllerSpec.scala
@@ -81,7 +81,7 @@ class IsThisFileConfidentialControllerSpec extends SpecBase with MockitoSugar {
 
     "must populate the form on a GET when the question has previously been answered" in {
 
-      val answers     = userAnswers.set(IsThisFileConfidentialPage(Index(0)), true).success.value
+      val answers     = userAnswers.set(WasThisFileConfidentialPage(Index(0)), true).success.value
       val application = applicationBuilder(userAnswers = Some(answers)).build()
       val request     = FakeRequest(GET, isThisFileConfidentialRoute)
       val view        = application.injector.instanceOf[IsThisFileConfidentialView]

--- a/test/controllers/RemoveSupportingDocumentControllerSpec.scala
+++ b/test/controllers/RemoveSupportingDocumentControllerSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 import base.SpecBase
 import forms.RemoveSupportingDocumentFormProvider
 import models.{Done, DraftId, Index, NormalMode, UploadedFile, UserAnswers}
+import models.DraftAttachment
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -44,10 +45,11 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
   val userAnswers = userAnswersAsIndividualTrader
 
   "must return OK and the correct view for a GET" in new SpecSetup {
-    val answers = (for {
-      ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
-      ua <- ua.set(WasThisFileConfidentialPage(Index(0)), false)
-    } yield ua).success.value
+    val answers =
+      userAnswers
+        .set(AllDocuments, List(DraftAttachment(successfulFile, Some(true))))
+        .success
+        .value
 
     val application = applicationBuilder(userAnswers = Some(answers))
       .overrides(
@@ -81,10 +83,11 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
     when(mockNavigator.nextPage(any(), any(), any()))
       .thenReturn(onwardRoute)
 
-    val answers = (for {
-      ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
-      ua <- ua.set(WasThisFileConfidentialPage(Index(0)), false)
-    } yield ua).success.value
+    val answers =
+      userAnswers
+        .set(AllDocuments, List(DraftAttachment(successfulFile, Some(false))))
+        .success
+        .value
 
     val application = applicationBuilder(userAnswers = Some(answers))
       .overrides(
@@ -110,16 +113,15 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
     )
 
     val updatedAnswers = userAnswersCaptor.getValue
-    updatedAnswers.get(UploadedFilePage(Index(0))) mustBe empty
-    updatedAnswers.get(WasThisFileConfidentialPage(Index(0))) mustBe empty
     updatedAnswers.get(AllDocuments) mustBe empty
   }
 
   "does not call the object store if the user answers 'No'" in new SpecSetup {
-    val answers = (for {
-      ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
-      ua <- ua.set(WasThisFileConfidentialPage(Index(0)), false)
-    } yield ua).success.value
+    val answers =
+      userAnswers
+        .set(AllDocuments, List(DraftAttachment(successfulFile, Some(false))))
+        .success
+        .value
 
     val application = applicationBuilder(userAnswers = Some(answers))
       .overrides(
@@ -163,7 +165,7 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
   "does not call object store if the file has no download url" in new SpecSetup {
 
     val answers = userAnswers
-      .set(UploadedFilePage(Index(0)), UploadedFile.Initiated("reference"))
+      .set(UploadSupportingDocumentPage, UploadedFile.Initiated("reference"))
       .success
       .value
 

--- a/test/controllers/RemoveSupportingDocumentControllerSpec.scala
+++ b/test/controllers/RemoveSupportingDocumentControllerSpec.scala
@@ -46,7 +46,7 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
   "must return OK and the correct view for a GET" in new SpecSetup {
     val answers = (for {
       ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
-      ua <- ua.set(IsThisFileConfidentialPage(Index(0)), false)
+      ua <- ua.set(WasThisFileConfidentialPage(Index(0)), false)
     } yield ua).success.value
 
     val application = applicationBuilder(userAnswers = Some(answers))
@@ -83,7 +83,7 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
 
     val answers = (for {
       ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
-      ua <- ua.set(IsThisFileConfidentialPage(Index(0)), false)
+      ua <- ua.set(WasThisFileConfidentialPage(Index(0)), false)
     } yield ua).success.value
 
     val application = applicationBuilder(userAnswers = Some(answers))
@@ -111,14 +111,14 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
 
     val updatedAnswers = userAnswersCaptor.getValue
     updatedAnswers.get(UploadedFilePage(Index(0))) mustBe empty
-    updatedAnswers.get(IsThisFileConfidentialPage(Index(0))) mustBe empty
+    updatedAnswers.get(WasThisFileConfidentialPage(Index(0))) mustBe empty
     updatedAnswers.get(AllDocuments) mustBe empty
   }
 
   "does not call the object store if the user answers 'No'" in new SpecSetup {
     val answers = (for {
       ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
-      ua <- ua.set(IsThisFileConfidentialPage(Index(0)), false)
+      ua <- ua.set(WasThisFileConfidentialPage(Index(0)), false)
     } yield ua).success.value
 
     val application = applicationBuilder(userAnswers = Some(answers))

--- a/test/controllers/RemoveSupportingDocumentControllerSpec.scala
+++ b/test/controllers/RemoveSupportingDocumentControllerSpec.scala
@@ -34,7 +34,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.Mockito.{never, times, verify, when}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{IsThisFileConfidentialPage, RemoveSupportingDocumentPage, UploadSupportingDocumentPage}
+import pages._
 import queries.AllDocuments
 import services.UserAnswersService
 import views.html.RemoveSupportingDocumentView
@@ -45,7 +45,7 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
 
   "must return OK and the correct view for a GET" in new SpecSetup {
     val answers = (for {
-      ua <- userAnswers.set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+      ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
       ua <- ua.set(IsThisFileConfidentialPage(Index(0)), false)
     } yield ua).success.value
 
@@ -82,7 +82,7 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
       .thenReturn(onwardRoute)
 
     val answers = (for {
-      ua <- userAnswers.set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+      ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
       ua <- ua.set(IsThisFileConfidentialPage(Index(0)), false)
     } yield ua).success.value
 
@@ -110,14 +110,14 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
     )
 
     val updatedAnswers = userAnswersCaptor.getValue
-    updatedAnswers.get(UploadSupportingDocumentPage(Index(0))) mustBe empty
+    updatedAnswers.get(UploadedFilePage(Index(0))) mustBe empty
     updatedAnswers.get(IsThisFileConfidentialPage(Index(0))) mustBe empty
     updatedAnswers.get(AllDocuments) mustBe empty
   }
 
   "does not call the object store if the user answers 'No'" in new SpecSetup {
     val answers = (for {
-      ua <- userAnswers.set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+      ua <- userAnswers.set(UploadedFilePage(Index(0)), successfulFile)
       ua <- ua.set(IsThisFileConfidentialPage(Index(0)), false)
     } yield ua).success.value
 
@@ -163,7 +163,7 @@ class RemoveSupportingDocumentControllerSpec extends SpecBase {
   "does not call object store if the file has no download url" in new SpecSetup {
 
     val answers = userAnswers
-      .set(UploadSupportingDocumentPage(Index(0)), UploadedFile.Initiated("reference"))
+      .set(UploadedFilePage(Index(0)), UploadedFile.Initiated("reference"))
       .success
       .value
 

--- a/test/controllers/UploadAnotherSupportingDocumentControllerSpec.scala
+++ b/test/controllers/UploadAnotherSupportingDocumentControllerSpec.scala
@@ -29,7 +29,7 @@ import forms.UploadAnotherSupportingDocumentFormProvider
 import models._
 import navigation.{FakeNavigator, Navigator}
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{IsThisFileConfidentialPage, UploadSupportingDocumentPage}
+import pages._
 import views.html.UploadAnotherSupportingDocumentView
 
 class UploadAnotherSupportingDocumentControllerSpec extends SpecBase with MockitoSugar {
@@ -61,7 +61,7 @@ class UploadAnotherSupportingDocumentControllerSpec extends SpecBase with Mockit
     "must return OK and the correct view for a GET" in {
 
       val answers = userAnswersAsIndividualTrader
-        .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+        .set(UploadedFilePage(Index(0)), successfulFile)
         .success
         .value
         .set(IsThisFileConfidentialPage(Index(0)), false)

--- a/test/controllers/UploadAnotherSupportingDocumentControllerSpec.scala
+++ b/test/controllers/UploadAnotherSupportingDocumentControllerSpec.scala
@@ -29,7 +29,7 @@ import forms.UploadAnotherSupportingDocumentFormProvider
 import models._
 import navigation.{FakeNavigator, Navigator}
 import org.scalatestplus.mockito.MockitoSugar
-import pages._
+import queries.DraftAttachmentAt
 import views.html.UploadAnotherSupportingDocumentView
 
 class UploadAnotherSupportingDocumentControllerSpec extends SpecBase with MockitoSugar {
@@ -61,10 +61,7 @@ class UploadAnotherSupportingDocumentControllerSpec extends SpecBase with Mockit
     "must return OK and the correct view for a GET" in {
 
       val answers = userAnswersAsIndividualTrader
-        .set(UploadedFilePage(Index(0)), successfulFile)
-        .success
-        .value
-        .set(WasThisFileConfidentialPage(Index(0)), false)
+        .set(DraftAttachmentAt(Index(0)), DraftAttachment(successfulFile, Some(false)))
         .success
         .value
 

--- a/test/controllers/UploadAnotherSupportingDocumentControllerSpec.scala
+++ b/test/controllers/UploadAnotherSupportingDocumentControllerSpec.scala
@@ -64,7 +64,7 @@ class UploadAnotherSupportingDocumentControllerSpec extends SpecBase with Mockit
         .set(UploadedFilePage(Index(0)), successfulFile)
         .success
         .value
-        .set(IsThisFileConfidentialPage(Index(0)), false)
+        .set(WasThisFileConfidentialPage(Index(0)), false)
         .success
         .value
 

--- a/test/controllers/UploadSupportingDocumentsControllerSpec.scala
+++ b/test/controllers/UploadSupportingDocumentsControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
 import base.SpecBase
-import models.{Index, NormalMode, UploadedFile}
+import models.{NormalMode, UploadedFile}
 import models.upscan.UpscanInitiateResponse
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
@@ -99,13 +99,13 @@ class UploadSupportingDocumentsControllerSpec
 
       val view = application.injector.instanceOf[UploadSupportingDocumentsView]
 
-      when(mockFileService.initiate(any(), any(), any())(any()))
+      when(mockFileService.initiate(any(), any())(any()))
         .thenReturn(Future.successful(upscanInitiateResponse))
 
       val request = FakeRequest(
         GET,
         controllers.routes.UploadSupportingDocumentsController
-          .onPageLoad(Index(0), models.NormalMode, draftId, None, None)
+          .onPageLoad(models.NormalMode, draftId, None, None)
           .url
       )
 
@@ -118,14 +118,14 @@ class UploadSupportingDocumentsControllerSpec
         errorMessage = None
       )(messages(application), request).toString
 
-      verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode), eqTo(Index(0)))(any())
+      verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode))(any())
     }
   }
 
   "when there is an initiated file" - {
 
     val userAnswers = userAnswersAsIndividualTrader
-      .set(UploadedFilePage(Index(0)), initiatedFile)
+      .set(UploadSupportingDocumentPage, initiatedFile)
       .success
       .value
 
@@ -141,13 +141,13 @@ class UploadSupportingDocumentsControllerSpec
 
         val view = application.injector.instanceOf[UploadSupportingDocumentsView]
 
-        when(mockFileService.initiate(any(), any(), any())(any()))
+        when(mockFileService.initiate(any(), any())(any()))
           .thenReturn(Future.successful(upscanInitiateResponse))
 
         val request = FakeRequest(
           GET,
           controllers.routes.UploadSupportingDocumentsController
-            .onPageLoad(Index(0), models.NormalMode, draftId, Some("errorCode"), None)
+            .onPageLoad(models.NormalMode, draftId, Some("errorCode"), None)
             .url
         )
 
@@ -160,7 +160,7 @@ class UploadSupportingDocumentsControllerSpec
           errorMessage = Some(messages(application)("uploadSupportingDocuments.error.unknown"))
         )(messages(application), request).toString
 
-        verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode), eqTo(Index(0)))(any())
+        verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode))(any())
       }
     }
 
@@ -181,7 +181,7 @@ class UploadSupportingDocumentsControllerSpec
           val request = FakeRequest(
             GET,
             controllers.routes.UploadSupportingDocumentsController
-              .onPageLoad(Index(0), models.NormalMode, draftId, None, Some("reference"))
+              .onPageLoad(models.NormalMode, draftId, None, Some("reference"))
               .url
           )
 
@@ -194,7 +194,7 @@ class UploadSupportingDocumentsControllerSpec
             errorMessage = None
           )(messages(application), request).toString
 
-          verify(mockFileService, times(0)).initiate(any(), any(), any())(any())
+          verify(mockFileService, times(0)).initiate(any(), any())(any())
         }
       }
 
@@ -210,13 +210,13 @@ class UploadSupportingDocumentsControllerSpec
 
           val view = application.injector.instanceOf[UploadSupportingDocumentsView]
 
-          when(mockFileService.initiate(any(), any(), any())(any()))
+          when(mockFileService.initiate(any(), any())(any()))
             .thenReturn(Future.successful(upscanInitiateResponse))
 
           val request = FakeRequest(
             GET,
             controllers.routes.UploadSupportingDocumentsController
-              .onPageLoad(Index(0), models.NormalMode, draftId, None, Some("otherReference"))
+              .onPageLoad(models.NormalMode, draftId, None, Some("otherReference"))
               .url
           )
 
@@ -229,7 +229,7 @@ class UploadSupportingDocumentsControllerSpec
             errorMessage = None
           )(messages(application), request).toString
 
-          verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode), eqTo(Index(0)))(any())
+          verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode))(any())
         }
       }
 
@@ -245,13 +245,13 @@ class UploadSupportingDocumentsControllerSpec
 
           val view = application.injector.instanceOf[UploadSupportingDocumentsView]
 
-          when(mockFileService.initiate(any(), any(), any())(any()))
+          when(mockFileService.initiate(any(), any())(any()))
             .thenReturn(Future.successful(upscanInitiateResponse))
 
           val request = FakeRequest(
             GET,
             controllers.routes.UploadSupportingDocumentsController
-              .onPageLoad(Index(0), models.NormalMode, draftId, None, None)
+              .onPageLoad(models.NormalMode, draftId, None, None)
               .url
           )
 
@@ -264,7 +264,7 @@ class UploadSupportingDocumentsControllerSpec
             errorMessage = None
           )(messages(application), request).toString
 
-          verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode), eqTo(Index(0)))(any())
+          verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode))(any())
         }
       }
     }
@@ -273,7 +273,7 @@ class UploadSupportingDocumentsControllerSpec
   "when there is a successful file" - {
 
     val userAnswers = userAnswersAsIndividualTrader
-      .set(UploadedFilePage(Index(0)), successfulFile)
+      .set(UploadSupportingDocumentPage, successfulFile)
       .success
       .value
 
@@ -294,7 +294,6 @@ class UploadSupportingDocumentsControllerSpec
           GET,
           controllers.routes.UploadSupportingDocumentsController
             .onPageLoad(
-              Index(0),
               models.NormalMode,
               draftId,
               None,
@@ -308,7 +307,7 @@ class UploadSupportingDocumentsControllerSpec
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual onwardRoute.url
 
-        verify(mockFileService, times(0)).initiate(any(), any(), any())(any())
+        verify(mockFileService, times(0)).initiate(any(), any())(any())
       }
     }
 
@@ -324,13 +323,13 @@ class UploadSupportingDocumentsControllerSpec
 
         val view = application.injector.instanceOf[UploadSupportingDocumentsView]
 
-        when(mockFileService.initiate(any(), any(), any())(any()))
+        when(mockFileService.initiate(any(), any())(any()))
           .thenReturn(Future.successful(upscanInitiateResponse))
 
         val request = FakeRequest(
           GET,
           controllers.routes.UploadSupportingDocumentsController
-            .onPageLoad(Index(0), models.NormalMode, draftId, None, Some("otherReference"))
+            .onPageLoad(models.NormalMode, draftId, None, Some("otherReference"))
             .url
         )
 
@@ -343,7 +342,7 @@ class UploadSupportingDocumentsControllerSpec
           errorMessage = None
         )(messages(application), request).toString
 
-        verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode), eqTo(Index(0)))(any())
+        verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode))(any())
       }
     }
 
@@ -359,13 +358,13 @@ class UploadSupportingDocumentsControllerSpec
 
         val view = application.injector.instanceOf[UploadSupportingDocumentsView]
 
-        when(mockFileService.initiate(any(), any(), any())(any()))
+        when(mockFileService.initiate(any(), any())(any()))
           .thenReturn(Future.successful(upscanInitiateResponse))
 
         val request = FakeRequest(
           GET,
           controllers.routes.UploadSupportingDocumentsController
-            .onPageLoad(Index(0), models.NormalMode, draftId, None, None)
+            .onPageLoad(models.NormalMode, draftId, None, None)
             .url
         )
 
@@ -378,7 +377,7 @@ class UploadSupportingDocumentsControllerSpec
           errorMessage = None
         )(messages(application), request).toString
 
-        verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode), eqTo(Index(0)))(any())
+        verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode))(any())
       }
     }
   }
@@ -387,7 +386,7 @@ class UploadSupportingDocumentsControllerSpec
 
     val userAnswers =
       userAnswersAsIndividualTrader
-        .set(UploadedFilePage(Index(0)), failedFile)
+        .set(UploadSupportingDocumentPage, failedFile)
         .success
         .value
 
@@ -399,13 +398,13 @@ class UploadSupportingDocumentsControllerSpec
         )
         .build()
 
-      when(mockFileService.initiate(any(), any(), any())(any()))
+      when(mockFileService.initiate(any(), any())(any()))
         .thenReturn(Future.successful(upscanInitiateResponse))
 
       val request = FakeRequest(
         GET,
         controllers.routes.UploadSupportingDocumentsController
-          .onPageLoad(Index(0), models.NormalMode, draftId, None, Some("key"))
+          .onPageLoad(models.NormalMode, draftId, None, Some("key"))
           .url
       )
 
@@ -413,57 +412,11 @@ class UploadSupportingDocumentsControllerSpec
 
       status(result) mustEqual SEE_OTHER
       redirectLocation(result).value mustEqual routes.UploadSupportingDocumentsController
-        .onPageLoad(Index(0), models.NormalMode, draftId, Some("Quarantine"), Some("key"))
+        .onPageLoad(models.NormalMode, draftId, Some("Quarantine"), Some("key"))
         .url
 
-      verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode), eqTo(Index(0)))(any())
+      verify(mockFileService).initiate(eqTo(draftId), eqTo(NormalMode))(any())
     }
-  }
-
-  "must return NOT_FOUND when the index is greater than the maximum number of files a user is allowed to upload" in {
-
-    val application = applicationBuilder(userAnswers = Some(userAnswersAsIndividualTrader))
-      .configure(
-        "upscan.maxFiles" -> 1
-      )
-      .build()
-
-    when(mockFileService.initiate(any(), any(), any())(any()))
-      .thenReturn(Future.successful(upscanInitiateResponse))
-
-    val request = FakeRequest(
-      GET,
-      controllers.routes.UploadSupportingDocumentsController
-        .onPageLoad(Index(1), models.NormalMode, draftId, None, Some("key"))
-        .url
-    )
-
-    val result = route(application, request).value
-
-    status(result) mustEqual NOT_FOUND
-  }
-
-  "must return NOT_FOUND when the index is greater than the greatest existing index + 1" in {
-
-    val application = applicationBuilder(userAnswers = Some(userAnswersAsIndividualTrader))
-      .configure(
-        "upscan.maxFiles" -> 5
-      )
-      .build()
-
-    when(mockFileService.initiate(any(), any(), any())(any()))
-      .thenReturn(Future.successful(upscanInitiateResponse))
-
-    val request = FakeRequest(
-      GET,
-      controllers.routes.UploadSupportingDocumentsController
-        .onPageLoad(Index(1), models.NormalMode, draftId, None, Some("key"))
-        .url
-    )
-
-    val result = route(application, request).value
-
-    status(result) mustEqual NOT_FOUND
   }
 
   "must redirect to the JourneyRecovery page when there are no user answers" in {
@@ -477,7 +430,7 @@ class UploadSupportingDocumentsControllerSpec
     val request = FakeRequest(
       GET,
       controllers.routes.UploadSupportingDocumentsController
-        .onPageLoad(Index(0), models.NormalMode, draftId, None, None)
+        .onPageLoad(models.NormalMode, draftId, None, None)
         .url
     )
 
@@ -486,6 +439,6 @@ class UploadSupportingDocumentsControllerSpec
     status(result) mustEqual SEE_OTHER
     redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
 
-    verify(mockFileService, times(0)).initiate(any(), any(), any())(any())
+    verify(mockFileService, times(0)).initiate(any(), any())(any())
   }
 }

--- a/test/controllers/UploadSupportingDocumentsControllerSpec.scala
+++ b/test/controllers/UploadSupportingDocumentsControllerSpec.scala
@@ -35,7 +35,7 @@ import org.mockito.Mockito.{verify, when}
 import org.mockito.MockitoSugar.{reset, times}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
-import pages.UploadSupportingDocumentPage
+import pages._
 import services.UserAnswersService
 import services.fileupload.FileService
 import views.html.UploadSupportingDocumentsView
@@ -125,7 +125,7 @@ class UploadSupportingDocumentsControllerSpec
   "when there is an initiated file" - {
 
     val userAnswers = userAnswersAsIndividualTrader
-      .set(UploadSupportingDocumentPage(Index(0)), initiatedFile)
+      .set(UploadedFilePage(Index(0)), initiatedFile)
       .success
       .value
 
@@ -273,7 +273,7 @@ class UploadSupportingDocumentsControllerSpec
   "when there is a successful file" - {
 
     val userAnswers = userAnswersAsIndividualTrader
-      .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+      .set(UploadedFilePage(Index(0)), successfulFile)
       .success
       .value
 
@@ -387,7 +387,7 @@ class UploadSupportingDocumentsControllerSpec
 
     val userAnswers =
       userAnswersAsIndividualTrader
-        .set(UploadSupportingDocumentPage(Index(0)), failedFile)
+        .set(UploadedFilePage(Index(0)), failedFile)
         .success
         .value
 

--- a/test/controllers/callback/UploadCallbackControllerSpec.scala
+++ b/test/controllers/callback/UploadCallbackControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
-import models.{Done, DraftId, Index, UploadedFile}
+import models.{Done, DraftId, UploadedFile}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.Mockito.{verify, when}
@@ -68,15 +68,15 @@ class UploadCallbackControllerSpec
 
     "must call the file service with the correct parameters" in {
 
-      when(mockFileService.update(any(), any(), any())).thenReturn(Future.successful(Done))
+      when(mockFileService.update(any(), any())).thenReturn(Future.successful(Done))
 
-      val request = FakeRequest(routes.UploadCallbackController.callback(DraftId(0), Index(0)))
+      val request = FakeRequest(routes.UploadCallbackController.callback(DraftId(0)))
         .withJsonBody(Json.toJson(requestBody))
       val result  = route(app, request).value
 
       status(result) mustBe OK
 
-      verify(mockFileService).update(eqTo(DraftId(0)), eqTo(Index(0)), any())
+      verify(mockFileService).update(eqTo(DraftId(0)), any())
     }
   }
 }

--- a/test/models/requests/AttachmentRequestSpec.scala
+++ b/test/models/requests/AttachmentRequestSpec.scala
@@ -25,7 +25,7 @@ import models.{DraftId, Index, UploadedFile, UserAnswers}
 import org.scalatest.{OptionValues, TryValues}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import pages.{DoYouWantToUploadDocumentsPage, IsThisFileConfidentialPage, UploadSupportingDocumentPage}
+import pages._
 
 class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues with OptionValues {
 
@@ -60,7 +60,7 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
         .set(DoYouWantToUploadDocumentsPage, false)
         .success
         .value
-        .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+        .set(UploadedFilePage(Index(0)), successfulFile)
         .success
         .value
         .set(IsThisFileConfidentialPage(Index(0)), false)
@@ -79,13 +79,13 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
           .set(DoYouWantToUploadDocumentsPage, true)
           .success
           .value
-          .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+          .set(UploadedFilePage(Index(0)), successfulFile)
           .success
           .value
           .set(IsThisFileConfidentialPage(Index(0)), false)
           .success
           .value
-          .set(UploadSupportingDocumentPage(Index(1)), successfulFile)
+          .set(UploadedFilePage(Index(1)), successfulFile)
           .success
           .value
           .set(IsThisFileConfidentialPage(Index(1)), true)
@@ -120,7 +120,7 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
 
       val answers = emptyUserAnswers.set(DoYouWantToUploadDocumentsPage, true).success.value
       val result  = AttachmentRequest(answers)
-      result mustBe Invalid(NonEmptyList.one(UploadSupportingDocumentPage(Index(0))))
+      result mustBe Invalid(NonEmptyList.one(UploadedFilePage(Index(0))))
     }
 
     "fail when there are non-successful files" in {
@@ -129,14 +129,14 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
         .set(DoYouWantToUploadDocumentsPage, true)
         .success
         .value
-        .set(UploadSupportingDocumentPage(Index(0)), failedFile)
+        .set(UploadedFilePage(Index(0)), failedFile)
         .success
         .value
         .set(IsThisFileConfidentialPage(Index(0)), true)
         .success
         .value
       val result  = AttachmentRequest(answers)
-      result mustBe Invalid(NonEmptyList.one(UploadSupportingDocumentPage(Index(0))))
+      result mustBe Invalid(NonEmptyList.one(UploadedFilePage(Index(0))))
     }
 
     "fail when privacy setting is missing from files" in {
@@ -145,7 +145,7 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
         .set(DoYouWantToUploadDocumentsPage, true)
         .success
         .value
-        .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+        .set(UploadedFilePage(Index(0)), successfulFile)
         .success
         .value
       val result  = AttachmentRequest(answers)

--- a/test/models/requests/AttachmentRequestSpec.scala
+++ b/test/models/requests/AttachmentRequestSpec.scala
@@ -63,7 +63,7 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
         .set(UploadedFilePage(Index(0)), successfulFile)
         .success
         .value
-        .set(IsThisFileConfidentialPage(Index(0)), false)
+        .set(WasThisFileConfidentialPage(Index(0)), false)
         .success
         .value
 
@@ -82,13 +82,13 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
           .set(UploadedFilePage(Index(0)), successfulFile)
           .success
           .value
-          .set(IsThisFileConfidentialPage(Index(0)), false)
+          .set(WasThisFileConfidentialPage(Index(0)), false)
           .success
           .value
           .set(UploadedFilePage(Index(1)), successfulFile)
           .success
           .value
-          .set(IsThisFileConfidentialPage(Index(1)), true)
+          .set(WasThisFileConfidentialPage(Index(1)), true)
           .success
           .value
 
@@ -132,7 +132,7 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
         .set(UploadedFilePage(Index(0)), failedFile)
         .success
         .value
-        .set(IsThisFileConfidentialPage(Index(0)), true)
+        .set(WasThisFileConfidentialPage(Index(0)), true)
         .success
         .value
       val result  = AttachmentRequest(answers)
@@ -149,7 +149,7 @@ class AttachmentRequestSpec extends AnyWordSpec with Matchers with TryValues wit
         .success
         .value
       val result  = AttachmentRequest(answers)
-      result mustBe Invalid(NonEmptyList.one(IsThisFileConfidentialPage(Index(0))))
+      result mustBe Invalid(NonEmptyList.one(WasThisFileConfidentialPage(Index(0))))
     }
   }
 }

--- a/test/navigation/CheckModeNavigatorSpec.scala
+++ b/test/navigation/CheckModeNavigatorSpec.scala
@@ -893,7 +893,7 @@ class CheckModeNavigatorSpec extends SpecBase {
 
           "UploadAnotherSupportingDocument page" in {
             navigator.nextPage(
-              IsThisFileConfidentialPage(Index(0)),
+              WasThisFileConfidentialPage(Index(0)),
               CheckMode,
               userAnswersAsIndividualTrader
             ) mustBe routes.UploadAnotherSupportingDocumentController.onPageLoad(CheckMode, draftId)
@@ -919,7 +919,7 @@ class CheckModeNavigatorSpec extends SpecBase {
                 .set(UploadedFilePage(Index(0)), successfulFile)
                 .success
                 .value
-                .set(IsThisFileConfidentialPage(Index(0)), true)
+                .set(WasThisFileConfidentialPage(Index(0)), true)
                 .success
                 .value
                 .set(UploadAnotherSupportingDocumentPage, true)
@@ -983,7 +983,7 @@ class CheckModeNavigatorSpec extends SpecBase {
                 .set(UploadedFilePage(Index(0)), successfulFile)
                 .success
                 .value
-                .set(IsThisFileConfidentialPage(Index(0)), true)
+                .set(WasThisFileConfidentialPage(Index(0)), true)
                 .success
                 .value
             navigator.nextPage(

--- a/test/navigation/CheckModeNavigatorSpec.scala
+++ b/test/navigation/CheckModeNavigatorSpec.scala
@@ -878,7 +878,7 @@ class CheckModeNavigatorSpec extends SpecBase {
 
           "IsThisFileConfidential page" in {
             navigator.nextPage(
-              UploadSupportingDocumentPage(Index(0)),
+              UploadedFilePage(Index(0)),
               CheckMode,
               userAnswersAsIndividualTrader
             ) mustBe routes.IsThisFileConfidentialController.onPageLoad(
@@ -916,7 +916,7 @@ class CheckModeNavigatorSpec extends SpecBase {
           "UploadSupportingDocumentsPage when Yes is selected and there are other files" in {
             val userAnswers =
               userAnswersAsIndividualTrader
-                .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+                .set(UploadedFilePage(Index(0)), successfulFile)
                 .success
                 .value
                 .set(IsThisFileConfidentialPage(Index(0)), true)
@@ -980,7 +980,7 @@ class CheckModeNavigatorSpec extends SpecBase {
           "UploadAnotherSupportingDocument page when there are more documents" in {
             val answers =
               userAnswersAsIndividualTrader
-                .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+                .set(UploadedFilePage(Index(0)), successfulFile)
                 .success
                 .value
                 .set(IsThisFileConfidentialPage(Index(0)), true)

--- a/test/navigation/CheckModeNavigatorSpec.scala
+++ b/test/navigation/CheckModeNavigatorSpec.scala
@@ -24,7 +24,7 @@ import base.SpecBase
 import controllers.routes
 import models._
 import pages._
-import queries.Modifiable
+import queries._
 
 class CheckModeNavigatorSpec extends SpecBase {
 
@@ -856,7 +856,6 @@ class CheckModeNavigatorSpec extends SpecBase {
               CheckMode,
               userAnswers
             ) mustBe controllers.routes.UploadSupportingDocumentsController.onPageLoad(
-              Index(0),
               CheckMode,
               draftId,
               None,
@@ -878,11 +877,10 @@ class CheckModeNavigatorSpec extends SpecBase {
 
           "IsThisFileConfidential page" in {
             navigator.nextPage(
-              UploadedFilePage(Index(0)),
+              UploadSupportingDocumentPage,
               CheckMode,
               userAnswersAsIndividualTrader
             ) mustBe routes.IsThisFileConfidentialController.onPageLoad(
-              Index(0),
               CheckMode,
               draftId
             )
@@ -893,7 +891,7 @@ class CheckModeNavigatorSpec extends SpecBase {
 
           "UploadAnotherSupportingDocument page" in {
             navigator.nextPage(
-              WasThisFileConfidentialPage(Index(0)),
+              IsThisFileConfidentialPage,
               CheckMode,
               userAnswersAsIndividualTrader
             ) mustBe routes.UploadAnotherSupportingDocumentController.onPageLoad(CheckMode, draftId)
@@ -910,26 +908,21 @@ class CheckModeNavigatorSpec extends SpecBase {
               CheckMode,
               userAnswers
             ) mustBe controllers.routes.UploadSupportingDocumentsController
-              .onPageLoad(Index(0), CheckMode, draftId, None, None)
+              .onPageLoad(CheckMode, draftId, None, None)
           }
 
           "UploadSupportingDocumentsPage when Yes is selected and there are other files" in {
-            val userAnswers =
-              userAnswersAsIndividualTrader
-                .set(UploadedFilePage(Index(0)), successfulFile)
-                .success
-                .value
-                .set(WasThisFileConfidentialPage(Index(0)), true)
-                .success
-                .value
-                .set(UploadAnotherSupportingDocumentPage, true)
-                .get
+            val userAnswers = (for {
+              ua <- EmptyUserAnswers.set(UploadAnotherSupportingDocumentPage, true)
+              ua <- ua.set(AllDocuments, List(DraftAttachment(successfulFile, Some(true))))
+            } yield ua).success.value
+
             navigator.nextPage(
               UploadAnotherSupportingDocumentPage,
               CheckMode,
               userAnswers
             ) mustBe controllers.routes.UploadSupportingDocumentsController
-              .onPageLoad(Index(1), CheckMode, draftId, None, None)
+              .onPageLoad(CheckMode, draftId, None, None)
           }
 
           "CheckYourAnswers page when No is selected and the user is an IndividualTrader" in {
@@ -980,12 +973,10 @@ class CheckModeNavigatorSpec extends SpecBase {
           "UploadAnotherSupportingDocument page when there are more documents" in {
             val answers =
               userAnswersAsIndividualTrader
-                .set(UploadedFilePage(Index(0)), successfulFile)
+                .set(AllDocuments, List(DraftAttachment(successfulFile, Some(true))))
                 .success
                 .value
-                .set(WasThisFileConfidentialPage(Index(0)), true)
-                .success
-                .value
+
             navigator.nextPage(
               RemoveSupportingDocumentPage(Index(0)),
               CheckMode,

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -371,7 +371,7 @@ class NavigatorSpec extends SpecBase {
 
             "must navigate to UploadAnotherSupportingDocument" in {
               val userAnswers = userAnswersWith(HasConfidentialInformationPage, false)
-                .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+                .set(UploadedFilePage(Index(0)), successfulFile)
                 .success
                 .value
                 .set(IsThisFileConfidentialPage(Index(0)), true)
@@ -405,7 +405,7 @@ class NavigatorSpec extends SpecBase {
         "navigate to UploadAnotherSupportingDocument page when there are existing documents" in {
           val userAnswers =
             userAnswersWith(ConfidentialInformationPage, "top secret")
-              .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+              .set(UploadedFilePage(Index(0)), successfulFile)
               .success
               .value
               .set(IsThisFileConfidentialPage(Index(0)), true)
@@ -645,7 +645,7 @@ class NavigatorSpec extends SpecBase {
 
         "IsThisFileConfidential page" in {
           navigator.nextPage(
-            UploadSupportingDocumentPage(Index(0)),
+            UploadedFilePage(Index(0)),
             NormalMode,
             userAnswersAsIndividualTrader
           ) mustBe routes.IsThisFileConfidentialController.onPageLoad(Index(0), NormalMode, draftId)
@@ -679,7 +679,7 @@ class NavigatorSpec extends SpecBase {
         "UploadSupportingDocumentsPage when Yes is selected and there are other files" in {
           val userAnswers =
             userAnswersAsIndividualTrader
-              .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+              .set(UploadedFilePage(Index(0)), successfulFile)
               .success
               .value
               .set(IsThisFileConfidentialPage(Index(0)), true)
@@ -743,7 +743,7 @@ class NavigatorSpec extends SpecBase {
         "UploadAnotherSupportingDocument page when there are more documents" in {
           val answers =
             userAnswersAsIndividualTrader
-              .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+              .set(UploadedFilePage(Index(0)), successfulFile)
               .success
               .value
               .set(IsThisFileConfidentialPage(Index(0)), true)

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -374,7 +374,7 @@ class NavigatorSpec extends SpecBase {
                 .set(UploadedFilePage(Index(0)), successfulFile)
                 .success
                 .value
-                .set(IsThisFileConfidentialPage(Index(0)), true)
+                .set(WasThisFileConfidentialPage(Index(0)), true)
                 .success
                 .value
               navigator.nextPage(
@@ -408,7 +408,7 @@ class NavigatorSpec extends SpecBase {
               .set(UploadedFilePage(Index(0)), successfulFile)
               .success
               .value
-              .set(IsThisFileConfidentialPage(Index(0)), true)
+              .set(WasThisFileConfidentialPage(Index(0)), true)
               .success
               .value
           navigator.nextPage(
@@ -656,7 +656,7 @@ class NavigatorSpec extends SpecBase {
 
         "UploadAnotherSupportingDocument page" in {
           navigator.nextPage(
-            IsThisFileConfidentialPage(Index(0)),
+            WasThisFileConfidentialPage(Index(0)),
             NormalMode,
             userAnswersAsIndividualTrader
           ) mustBe routes.UploadAnotherSupportingDocumentController.onPageLoad(NormalMode, draftId)
@@ -682,7 +682,7 @@ class NavigatorSpec extends SpecBase {
               .set(UploadedFilePage(Index(0)), successfulFile)
               .success
               .value
-              .set(IsThisFileConfidentialPage(Index(0)), true)
+              .set(WasThisFileConfidentialPage(Index(0)), true)
               .success
               .value
               .set(UploadAnotherSupportingDocumentPage, true)
@@ -746,7 +746,7 @@ class NavigatorSpec extends SpecBase {
               .set(UploadedFilePage(Index(0)), successfulFile)
               .success
               .value
-              .set(IsThisFileConfidentialPage(Index(0)), true)
+              .set(WasThisFileConfidentialPage(Index(0)), true)
               .success
               .value
           navigator.nextPage(

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -28,7 +28,7 @@ import models._
 import models.AuthUserType.{Agent, IndividualTrader, OrganisationAdmin, OrganisationAssistant}
 import models.WhatIsYourRoleAsImporter.{AgentOnBehalfOfOrg, EmployeeOfOrg}
 import pages._
-import queries.Modifiable
+import queries._
 
 class NavigatorSpec extends SpecBase {
 
@@ -370,13 +370,11 @@ class NavigatorSpec extends SpecBase {
           "when there are existing documents" - {
 
             "must navigate to UploadAnotherSupportingDocument" in {
-              val userAnswers = userAnswersWith(HasConfidentialInformationPage, false)
-                .set(UploadedFilePage(Index(0)), successfulFile)
-                .success
-                .value
-                .set(WasThisFileConfidentialPage(Index(0)), true)
-                .success
-                .value
+              val userAnswers = (for {
+                ua <- EmptyUserAnswers.set(HasConfidentialInformationPage, false)
+                ua <- ua.set(AllDocuments, List(DraftAttachment(successfulFile, Some(true))))
+              } yield ua).success.value
+
               navigator.nextPage(
                 HasConfidentialInformationPage,
                 NormalMode,
@@ -403,14 +401,11 @@ class NavigatorSpec extends SpecBase {
         }
 
         "navigate to UploadAnotherSupportingDocument page when there are existing documents" in {
-          val userAnswers =
-            userAnswersWith(ConfidentialInformationPage, "top secret")
-              .set(UploadedFilePage(Index(0)), successfulFile)
-              .success
-              .value
-              .set(WasThisFileConfidentialPage(Index(0)), true)
-              .success
-              .value
+          val userAnswers = (for {
+            ua <- EmptyUserAnswers.set(ConfidentialInformationPage, "top secret")
+            ua <- ua.set(AllDocuments, List(DraftAttachment(successfulFile, Some(true))))
+          } yield ua).success.value
+
           navigator.nextPage(
             ConfidentialInformationPage,
             NormalMode,
@@ -627,7 +622,7 @@ class NavigatorSpec extends SpecBase {
             NormalMode,
             userAnswers
           ) mustBe controllers.routes.UploadSupportingDocumentsController
-            .onPageLoad(Index(0), NormalMode, draftId, None, None)
+            .onPageLoad(NormalMode, draftId, None, None)
         }
 
         "CheckYourAnswers page when No is selected" in {
@@ -645,10 +640,10 @@ class NavigatorSpec extends SpecBase {
 
         "IsThisFileConfidential page" in {
           navigator.nextPage(
-            UploadedFilePage(Index(0)),
+            UploadSupportingDocumentPage,
             NormalMode,
             userAnswersAsIndividualTrader
-          ) mustBe routes.IsThisFileConfidentialController.onPageLoad(Index(0), NormalMode, draftId)
+          ) mustBe routes.IsThisFileConfidentialController.onPageLoad(NormalMode, draftId)
         }
       }
 
@@ -656,7 +651,7 @@ class NavigatorSpec extends SpecBase {
 
         "UploadAnotherSupportingDocument page" in {
           navigator.nextPage(
-            WasThisFileConfidentialPage(Index(0)),
+            IsThisFileConfidentialPage,
             NormalMode,
             userAnswersAsIndividualTrader
           ) mustBe routes.UploadAnotherSupportingDocumentController.onPageLoad(NormalMode, draftId)
@@ -673,26 +668,22 @@ class NavigatorSpec extends SpecBase {
             NormalMode,
             userAnswers
           ) mustBe controllers.routes.UploadSupportingDocumentsController
-            .onPageLoad(Index(0), NormalMode, draftId, None, None)
+            .onPageLoad(NormalMode, draftId, None, None)
         }
 
         "UploadSupportingDocumentsPage when Yes is selected and there are other files" in {
-          val userAnswers =
-            userAnswersAsIndividualTrader
-              .set(UploadedFilePage(Index(0)), successfulFile)
-              .success
-              .value
-              .set(WasThisFileConfidentialPage(Index(0)), true)
-              .success
-              .value
-              .set(UploadAnotherSupportingDocumentPage, true)
-              .get
+          val userAnswers = (for {
+            ua <- EmptyUserAnswers.set(UploadSupportingDocumentPage, successfulFile)
+            ua <- ua.set(IsThisFileConfidentialPage, true)
+            ua <- ua.set(UploadAnotherSupportingDocumentPage, true)
+          } yield ua).success.value
+
           navigator.nextPage(
             UploadAnotherSupportingDocumentPage,
             NormalMode,
             userAnswers
           ) mustBe controllers.routes.UploadSupportingDocumentsController
-            .onPageLoad(Index(1), NormalMode, draftId, None, None)
+            .onPageLoad(NormalMode, draftId, None, None)
         }
 
         "CheckYourAnswers page when No is selected and the user is an IndividualTrader" in {
@@ -743,12 +734,10 @@ class NavigatorSpec extends SpecBase {
         "UploadAnotherSupportingDocument page when there are more documents" in {
           val answers =
             userAnswersAsIndividualTrader
-              .set(UploadedFilePage(Index(0)), successfulFile)
+              .set(AllDocuments, List(DraftAttachment(successfulFile, Some(true))))
               .success
               .value
-              .set(WasThisFileConfidentialPage(Index(0)), true)
-              .success
-              .value
+
           navigator.nextPage(
             RemoveSupportingDocumentPage(Index(0)),
             NormalMode,

--- a/test/pages/DoYouWantToUploadDocumentsPageSpec.scala
+++ b/test/pages/DoYouWantToUploadDocumentsPageSpec.scala
@@ -49,13 +49,13 @@ class DoYouWantToUploadDocumentsPageSpec extends PageBehaviours {
         .set(UploadedFilePage(Index(0)), successfulFile)
         .success
         .value
-        .set(IsThisFileConfidentialPage(Index(0)), true)
+        .set(WasThisFileConfidentialPage(Index(0)), true)
         .success
         .value
         .set(UploadedFilePage(Index(1)), successfulFile)
         .success
         .value
-        .set(IsThisFileConfidentialPage(Index(1)), false)
+        .set(WasThisFileConfidentialPage(Index(1)), false)
         .success
         .value
 
@@ -63,9 +63,9 @@ class DoYouWantToUploadDocumentsPageSpec extends PageBehaviours {
         existingAnswers.set(DoYouWantToUploadDocumentsPage, false).success.value
 
       cleanedUpAnswers.get(UploadedFilePage(Index(0))) mustBe empty
-      cleanedUpAnswers.get(IsThisFileConfidentialPage(Index(0))) mustBe empty
+      cleanedUpAnswers.get(WasThisFileConfidentialPage(Index(0))) mustBe empty
       cleanedUpAnswers.get(UploadedFilePage(Index(1))) mustBe empty
-      cleanedUpAnswers.get(IsThisFileConfidentialPage(Index(1))) mustBe empty
+      cleanedUpAnswers.get(WasThisFileConfidentialPage(Index(1))) mustBe empty
     }
   }
 }

--- a/test/pages/DoYouWantToUploadDocumentsPageSpec.scala
+++ b/test/pages/DoYouWantToUploadDocumentsPageSpec.scala
@@ -19,7 +19,9 @@ package pages
 import java.time.Instant
 
 import models.{DraftId, Index, UploadedFile, UserAnswers}
+import models.DraftAttachment
 import pages.behaviours.PageBehaviours
+import queries.{AllDocuments, DraftAttachmentAt}
 
 class DoYouWantToUploadDocumentsPageSpec extends PageBehaviours {
 
@@ -33,7 +35,7 @@ class DoYouWantToUploadDocumentsPageSpec extends PageBehaviours {
 
     "must remove any uploaded documents when the user chooses no" in {
 
-      val successfulFile = UploadedFile.Success(
+      val successfulFile  = UploadedFile.Success(
         reference = "reference",
         downloadUrl = "downloadUrl",
         uploadDetails = UploadedFile.UploadDetails(
@@ -44,28 +46,17 @@ class DoYouWantToUploadDocumentsPageSpec extends PageBehaviours {
           size = 1337
         )
       )
-
-      val existingAnswers = UserAnswers("userId", DraftId(0))
-        .set(UploadedFilePage(Index(0)), successfulFile)
-        .success
-        .value
-        .set(WasThisFileConfidentialPage(Index(0)), true)
-        .success
-        .value
-        .set(UploadedFilePage(Index(1)), successfulFile)
-        .success
-        .value
-        .set(WasThisFileConfidentialPage(Index(1)), false)
-        .success
-        .value
+      val emptyAnswers    = UserAnswers("userId", DraftId(0))
+      val existingAnswers = (for {
+        ua <-
+          emptyAnswers.set(DraftAttachmentAt(Index(0)), DraftAttachment(successfulFile, Some(true)))
+        ua <- ua.set(DraftAttachmentAt(Index(1)), DraftAttachment(successfulFile, Some(false)))
+      } yield ua).success.value
 
       val cleanedUpAnswers =
         existingAnswers.set(DoYouWantToUploadDocumentsPage, false).success.value
 
-      cleanedUpAnswers.get(UploadedFilePage(Index(0))) mustBe empty
-      cleanedUpAnswers.get(WasThisFileConfidentialPage(Index(0))) mustBe empty
-      cleanedUpAnswers.get(UploadedFilePage(Index(1))) mustBe empty
-      cleanedUpAnswers.get(WasThisFileConfidentialPage(Index(1))) mustBe empty
+      cleanedUpAnswers.get(AllDocuments) mustBe empty
     }
   }
 }

--- a/test/pages/DoYouWantToUploadDocumentsPageSpec.scala
+++ b/test/pages/DoYouWantToUploadDocumentsPageSpec.scala
@@ -46,13 +46,13 @@ class DoYouWantToUploadDocumentsPageSpec extends PageBehaviours {
       )
 
       val existingAnswers = UserAnswers("userId", DraftId(0))
-        .set(UploadSupportingDocumentPage(Index(0)), successfulFile)
+        .set(UploadedFilePage(Index(0)), successfulFile)
         .success
         .value
         .set(IsThisFileConfidentialPage(Index(0)), true)
         .success
         .value
-        .set(UploadSupportingDocumentPage(Index(1)), successfulFile)
+        .set(UploadedFilePage(Index(1)), successfulFile)
         .success
         .value
         .set(IsThisFileConfidentialPage(Index(1)), false)
@@ -62,9 +62,9 @@ class DoYouWantToUploadDocumentsPageSpec extends PageBehaviours {
       val cleanedUpAnswers =
         existingAnswers.set(DoYouWantToUploadDocumentsPage, false).success.value
 
-      cleanedUpAnswers.get(UploadSupportingDocumentPage(Index(0))) mustBe empty
+      cleanedUpAnswers.get(UploadedFilePage(Index(0))) mustBe empty
       cleanedUpAnswers.get(IsThisFileConfidentialPage(Index(0))) mustBe empty
-      cleanedUpAnswers.get(UploadSupportingDocumentPage(Index(1))) mustBe empty
+      cleanedUpAnswers.get(UploadedFilePage(Index(1))) mustBe empty
       cleanedUpAnswers.get(IsThisFileConfidentialPage(Index(1))) mustBe empty
     }
   }

--- a/test/pages/IsThisFileConfidentialPageSpec.scala
+++ b/test/pages/IsThisFileConfidentialPageSpec.scala
@@ -23,10 +23,10 @@ class IsThisFileConfidentialPageSpec extends PageBehaviours {
 
   "IsThisFileConfidentialPage" - {
 
-    beRetrievable[Boolean](IsThisFileConfidentialPage(Index(0)))
+    beRetrievable[Boolean](WasThisFileConfidentialPage(Index(0)))
 
-    beSettable[Boolean](IsThisFileConfidentialPage(Index(0)))
+    beSettable[Boolean](WasThisFileConfidentialPage(Index(0)))
 
-    beRemovable[Boolean](IsThisFileConfidentialPage(Index(0)))
+    beRemovable[Boolean](WasThisFileConfidentialPage(Index(0)))
   }
 }

--- a/test/pages/IsThisFileConfidentialPageSpec.scala
+++ b/test/pages/IsThisFileConfidentialPageSpec.scala
@@ -16,17 +16,16 @@
 
 package pages
 
-import models.Index
 import pages.behaviours.PageBehaviours
 
 class IsThisFileConfidentialPageSpec extends PageBehaviours {
 
   "IsThisFileConfidentialPage" - {
 
-    beRetrievable[Boolean](WasThisFileConfidentialPage(Index(0)))
+    beRetrievable[Boolean](IsThisFileConfidentialPage)
 
-    beSettable[Boolean](WasThisFileConfidentialPage(Index(0)))
+    beSettable[Boolean](IsThisFileConfidentialPage)
 
-    beRemovable[Boolean](WasThisFileConfidentialPage(Index(0)))
+    beRemovable[Boolean](IsThisFileConfidentialPage)
   }
 }

--- a/test/services/fileupload/FileServiceSpec.scala
+++ b/test/services/fileupload/FileServiceSpec.scala
@@ -121,7 +121,7 @@ class FileServiceSpec
 
       val actualAnswers = userAnswersCaptor.getValue
 
-      actualAnswers.get(UploadSupportingDocumentPage(Index(0))).value mustEqual UploadedFile
+      actualAnswers.get(UploadedFilePage(Index(0))).value mustEqual UploadedFile
         .Initiated("reference")
     }
 
@@ -187,7 +187,7 @@ class FileServiceSpec
         val updatedFile = uploadedFile.copy(downloadUrl = "drafts/DRAFT000000000/foobar")
 
         val expectedAnswers = userAnswers
-          .set(UploadSupportingDocumentPage(Index(0)), updatedFile)
+          .set(UploadedFilePage(Index(0)), updatedFile)
           .success
           .value
 
@@ -218,7 +218,7 @@ class FileServiceSpec
       "must update the user answers with the status of the file" in {
 
         val expectedAnswers = userAnswers
-          .set(UploadSupportingDocumentPage(Index(0)), uploadedFile)
+          .set(UploadedFilePage(Index(0)), uploadedFile)
           .success
           .value
 
@@ -268,7 +268,7 @@ class FileServiceSpec
         )
 
         val userAnswers = UserAnswers("userId", DraftId(0))
-          .set(UploadSupportingDocumentPage(Index(0)), file1)
+          .set(UploadedFilePage(Index(0)), file1)
           .success
           .value
           .set(IsThisFileConfidentialPage(Index(0)), true)
@@ -276,7 +276,7 @@ class FileServiceSpec
           .value
 
         val expectedAnswers = userAnswers
-          .set(UploadSupportingDocumentPage(Index(1)), file3)
+          .set(UploadedFilePage(Index(1)), file3)
           .success
           .value
 
@@ -321,12 +321,12 @@ class FileServiceSpec
         )
 
         val userAnswers = UserAnswers("userId", DraftId(0))
-          .set(UploadSupportingDocumentPage(Index(0)), file1)
+          .set(UploadedFilePage(Index(0)), file1)
           .success
           .value
 
         val expectedAnswers = userAnswers
-          .set(UploadSupportingDocumentPage(Index(0)), file3)
+          .set(UploadedFilePage(Index(0)), file3)
           .success
           .value
 

--- a/test/services/fileupload/FileServiceSpec.scala
+++ b/test/services/fileupload/FileServiceSpec.scala
@@ -27,7 +27,8 @@ import uk.gov.hmrc.objectstore.client.{Md5Hash, ObjectSummaryWithMd5, Path}
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 
 import connectors.UpscanConnector
-import models.{Done, DraftId, Index, NormalMode, UploadedFile, UserAnswers}
+import models.{Done, DraftId, NormalMode, UploadedFile, UserAnswers}
+import models.DraftAttachment
 import models.upscan.{UpscanInitiateRequest, UpscanInitiateResponse}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -38,7 +39,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
-import pages.{IsThisFileConfidentialPage, UploadSupportingDocumentPage}
+import pages.UploadSupportingDocumentPage
+import queries.AllDocuments
 import services.UserAnswersService
 
 class FileServiceSpec
@@ -96,13 +98,13 @@ class FileServiceSpec
       val userAnswers = UserAnswers("userId", DraftId(0))
 
       val expectedPath = controllers.routes.UploadSupportingDocumentsController
-        .onPageLoad(Index(0), NormalMode, DraftId(0), None, None)
+        .onPageLoad(NormalMode, DraftId(0), None, None)
         .url
       val expectedUrl  = s"host$expectedPath"
 
       val expectedRequest = UpscanInitiateRequest(
         callbackUrl = s"http://localhost:12600${controllers.callback.routes.UploadCallbackController
-            .callback(DraftId(0), Index(0))}",
+            .callback(DraftId(0))}",
         successRedirect = expectedUrl,
         errorRedirect = expectedUrl,
         minimumFileSize = 123,
@@ -114,27 +116,29 @@ class FileServiceSpec
         .thenReturn(Future.successful(Some(userAnswers)))
       when(mockUserAnswersService.set(any())(any())).thenReturn(Future.successful(Done))
 
-      service.initiate(DraftId(0), NormalMode, Index(0))(hc).futureValue mustEqual response
+      service.initiate(DraftId(0), NormalMode)(hc).futureValue mustEqual response
 
       verify(mockUpscanConnector).initiate(eqTo(expectedRequest))(eqTo(hc))
       verify(mockUserAnswersService).set(userAnswersCaptor.capture())(any())
 
       val actualAnswers = userAnswersCaptor.getValue
 
-      actualAnswers.get(UploadedFilePage(Index(0))).value mustEqual UploadedFile
-        .Initiated("reference")
+      actualAnswers.get(UploadSupportingDocumentPage).value mustEqual UploadedFile.Initiated(
+        "reference"
+      )
+      actualAnswers.get(AllDocuments) mustEqual None
     }
 
     "fail when there are no user answers for that draft" in {
 
       val expectedPath = controllers.routes.UploadSupportingDocumentsController
-        .onPageLoad(Index(0), NormalMode, DraftId(0), None, None)
+        .onPageLoad(NormalMode, DraftId(0), None, None)
         .url
       val expectedUrl  = s"host$expectedPath"
 
       val expectedRequest = UpscanInitiateRequest(
         callbackUrl = s"http://localhost:12600${controllers.callback.routes.UploadCallbackController
-            .callback(DraftId(0), Index(0))}",
+            .callback(DraftId(0))}",
         successRedirect = expectedUrl,
         errorRedirect = expectedUrl,
         minimumFileSize = 123,
@@ -144,7 +148,7 @@ class FileServiceSpec
       when(mockUpscanConnector.initiate(any())(any())).thenReturn(Future.successful(response))
       when(mockUserAnswersService.get(any())(any())).thenReturn(Future.successful(None))
 
-      val exception = service.initiate(DraftId(0), NormalMode, Index(0))(hc).failed.futureValue
+      val exception = service.initiate(DraftId(0), NormalMode)(hc).failed.futureValue
 
       verify(mockUpscanConnector).initiate(eqTo(expectedRequest))(eqTo(hc))
 
@@ -187,7 +191,7 @@ class FileServiceSpec
         val updatedFile = uploadedFile.copy(downloadUrl = "drafts/DRAFT000000000/foobar")
 
         val expectedAnswers = userAnswers
-          .set(UploadedFilePage(Index(0)), updatedFile)
+          .set(UploadSupportingDocumentPage, updatedFile)
           .success
           .value
 
@@ -197,7 +201,7 @@ class FileServiceSpec
           .thenReturn(Future.successful(objectSummary))
         when(mockUserAnswersService.setInternal(any())(any())).thenReturn(Future.successful(Done))
 
-        service.update(DraftId(0), Index(0), uploadedFile).futureValue
+        service.update(DraftId(0), uploadedFile).futureValue
 
         verify(mockUserAnswersService).getInternal(eqTo(DraftId(0)))(any())
         verify(mockObjectStoreClient).uploadFromUrl(any(), any(), any(), any(), any(), any())(any())
@@ -218,7 +222,7 @@ class FileServiceSpec
       "must update the user answers with the status of the file" in {
 
         val expectedAnswers = userAnswers
-          .set(UploadedFilePage(Index(0)), uploadedFile)
+          .set(UploadSupportingDocumentPage, uploadedFile)
           .success
           .value
 
@@ -226,7 +230,7 @@ class FileServiceSpec
           .thenReturn(Future.successful(Some(userAnswers)))
         when(mockUserAnswersService.setInternal(any())(any())).thenReturn(Future.successful(Done))
 
-        service.update(DraftId(0), Index(0), uploadedFile).futureValue
+        service.update(DraftId(0), uploadedFile).futureValue
 
         verify(mockUserAnswersService).getInternal(eqTo(DraftId(0)))(any())
         verify(mockObjectStoreClient, never).uploadFromUrl(
@@ -268,15 +272,12 @@ class FileServiceSpec
         )
 
         val userAnswers = UserAnswers("userId", DraftId(0))
-          .set(UploadedFilePage(Index(0)), file1)
-          .success
-          .value
-          .set(WasThisFileConfidentialPage(Index(0)), true)
+          .set(AllDocuments, List(DraftAttachment(file1, Some(true))))
           .success
           .value
 
         val expectedAnswers = userAnswers
-          .set(UploadedFilePage(Index(1)), file3)
+          .set(UploadSupportingDocumentPage, file3)
           .success
           .value
 
@@ -284,7 +285,7 @@ class FileServiceSpec
           .thenReturn(Future.successful(Some(userAnswers)))
         when(mockUserAnswersService.setInternal(any())(any())).thenReturn(Future.successful(Done))
 
-        service.update(DraftId(0), Index(1), file2).futureValue
+        service.update(DraftId(0), file2).futureValue
 
         verify(mockUserAnswersService).getInternal(eqTo(DraftId(0)))(any())
         verify(mockObjectStoreClient, never).uploadFromUrl(
@@ -321,12 +322,12 @@ class FileServiceSpec
         )
 
         val userAnswers = UserAnswers("userId", DraftId(0))
-          .set(UploadedFilePage(Index(0)), file1)
+          .set(UploadSupportingDocumentPage, file1)
           .success
           .value
 
         val expectedAnswers = userAnswers
-          .set(UploadedFilePage(Index(0)), file3)
+          .set(UploadSupportingDocumentPage, file3)
           .success
           .value
 
@@ -336,7 +337,7 @@ class FileServiceSpec
           .thenReturn(Future.successful(objectSummary))
         when(mockUserAnswersService.setInternal(any())(any())).thenReturn(Future.successful(Done))
 
-        service.update(DraftId(0), Index(0), file2).futureValue
+        service.update(DraftId(0), file2).futureValue
 
         verify(mockUserAnswersService).getInternal(eqTo(DraftId(0)))(any())
         verify(mockObjectStoreClient).uploadFromUrl(any(), any(), any(), any(), any(), any())(any())
@@ -362,7 +363,7 @@ class FileServiceSpec
       when(mockObjectStoreClient.uploadFromUrl(any(), any(), any(), any(), any(), any())(any()))
         .thenReturn(Future.successful(objectSummary))
 
-      service.update(DraftId(0), Index(0), uploadedFile).failed.futureValue
+      service.update(DraftId(0), uploadedFile).failed.futureValue
 
       verify(mockObjectStoreClient, never).uploadFromUrl(
         any(),

--- a/test/services/fileupload/FileServiceSpec.scala
+++ b/test/services/fileupload/FileServiceSpec.scala
@@ -271,7 +271,7 @@ class FileServiceSpec
           .set(UploadedFilePage(Index(0)), file1)
           .success
           .value
-          .set(IsThisFileConfidentialPage(Index(0)), true)
+          .set(WasThisFileConfidentialPage(Index(0)), true)
           .success
           .value
 


### PR DESCRIPTION
### Type of change
- [X] Non-breaking change

### Description
Essentially, unless a file has completed the file upload journey (uploaded successfully AND has confidentially market) it will not progress to the `AllDocuments` list. This prevents issues with invalid states within AllDocuments, which were easily repeatable by using the back button, loading a draft application, or url hacking

This fixes the underlying issue for ARS-950 and ARS-951

Note the acceptance tests already pass with these changes

The only draft applications that would be affected by these changes would be those with broken file upload journeys. In the current system, such  applications require all files to be removed and then reuploaded to be fixed. The same steps would fix them with this change -- so they are unaffected by this change

### Attachments or Screenshots

Handling an 'initiated' only upload

https://github.com/hmrc/advance-valuation-rulings-frontend/assets/8013000/498689eb-3913-4d99-a220-aef300d350d0

Handle no confidentiality upload (and prove more uploads can be done afterwards):

https://github.com/hmrc/advance-valuation-rulings-frontend/assets/8013000/fc39872f-2838-4d41-828d-d22d5e8a1c39

Fixed for returning from the cancellation page to the confidentiality page:

https://github.com/hmrc/advance-valuation-rulings-frontend/assets/8013000/de27d949-073b-42ac-ab5a-ba137748147f

