### PR TITLE
various provide-trader-eori fixes

### DIFF
--- a/app/controllers/ProvideTraderEoriController.scala
+++ b/app/controllers/ProvideTraderEoriController.scala
@@ -30,7 +30,7 @@ import connectors.BackendConnector
 import controllers.actions._
 import controllers.common.TraderDetailsHelper
 import forms.TraderEoriNumberFormProvider
-import models.{DraftId, Mode, TraderDetailsWithCountryCode}
+import models.{DraftId, EoriNumber, Mode, TraderDetailsWithCountryCode}
 import navigation.Navigator
 import pages.{ProvideTraderEoriPage, VerifyTraderDetailsPage}
 import services.UserAnswersService
@@ -105,7 +105,8 @@ class ProvideTraderEoriController @Inject() (
                                 )
                               )
                           },
-                        Some(Future.successful(NotFound(invalidEoriView(mode, draftId, value))))
+                        Some(Future.successful(NotFound(invalidEoriView(mode, draftId, value)))),
+                        Some(EoriNumber(value))
                       )
                   }
                 case Failure(error)       =>

--- a/app/controllers/common/TraderDetailsHelper.scala
+++ b/app/controllers/common/TraderDetailsHelper.scala
@@ -30,9 +30,11 @@ import models.{AcknowledgementReference, EoriNumber, TraderDetailsWithCountryCod
 import models.requests.DataRequest
 
 trait TraderDetailsHelper {
+
   def getTraderDetails(
     handleSuccess: TraderDetailsWithCountryCode => Future[Result],
-    notFound: Option[Future[Result]] = None
+    notFound: Option[Future[Result]] = None,
+    eori: Option[EoriNumber] = None
   )(implicit
     request: DataRequest[AnyContent],
     backendConnector: BackendConnector,
@@ -43,7 +45,7 @@ trait TraderDetailsHelper {
     backendConnector
       .getTraderDetails(
         AcknowledgementReference(request.userAnswers.draftId),
-        EoriNumber(request.eoriNumber)
+        eori.getOrElse(EoriNumber(request.eoriNumber))
       )
       .flatMap {
         r =>

--- a/app/forms/TraderEoriNumberFormProvider.scala
+++ b/app/forms/TraderEoriNumberFormProvider.scala
@@ -37,14 +37,14 @@ class TraderEoriNumberFormProvider @Inject() extends Mappings {
 
   private val validEORINumber: Constraint[String] =
     Constraint {
-      case formatRegex()            => Valid
-      case s if s.length > 14       =>
+      case formatRegex()                     => Valid
+      case s if s.length > 14                =>
         Invalid(ValidationError("provideTraderEori.error.tooLong"))
-      case s if s.length < 14       =>
+      case s if s.length < 14                =>
         Invalid(ValidationError("provideTraderEori.error.tooShort"))
-      case s if !s.startsWith("GB") =>
+      case s if !s.startsWith("GB")          =>
         Invalid(ValidationError("provideTraderEori.error.notGB"))
-      case _                        =>
-        Invalid(ValidationError("provideTraderEori.error.general"))
+      case s if !s.forall(_.isLetterOrDigit) =>
+        Invalid(ValidationError("provideTraderEori.error.specialCharacters"))
     }
 }

--- a/app/forms/TraderEoriNumberFormProvider.scala
+++ b/app/forms/TraderEoriNumberFormProvider.scala
@@ -46,5 +46,7 @@ class TraderEoriNumberFormProvider @Inject() extends Mappings {
         Invalid(ValidationError("provideTraderEori.error.notGB"))
       case s if !s.forall(_.isLetterOrDigit) =>
         Invalid(ValidationError("provideTraderEori.error.specialCharacters"))
+      case _                                 =>
+        Invalid(ValidationError("provideTraderEori.error.default"))
     }
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -866,6 +866,7 @@ provideTraderEori.error.tooLong=EORI number is too long
 provideTraderEori.error.tooShort=EORI number is not long enough
 provideTraderEori.error.notGB=Enter EORI number beginning with GB
 provideTraderEori.error.specialCharacters=Enter an EORI number in the correct format, like GB123456789010
+provideTraderEori.error.default=Enter an EORI number in the correct format, like GB123456789010
 
 #TRADER DETAILS - COMMON
 traderDetails.common.searchAgain=<a href="{0}" class="govuk-link">Search again</a> if you think you entered the trader''s EORI number incorrectly.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -865,7 +865,7 @@ provideTraderEori.error.required=Enter the trader''s EORI number
 provideTraderEori.error.tooLong=EORI number is too long
 provideTraderEori.error.tooShort=EORI number is not long enough
 provideTraderEori.error.notGB=Enter EORI number beginning with GB
-provideTraderEori.error.general=EORI country code can only be GB followed by 12 digits, like GB123456123456
+provideTraderEori.error.specialCharacters=Enter an EORI number in the correct format, like GB123456789010
 
 #TRADER DETAILS - COMMON
 traderDetails.common.searchAgain=<a href="{0}" class="govuk-link">Search again</a> if you think you entered the trader''s EORI number incorrectly.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -204,6 +204,7 @@ provideTraderEori.error.tooLong=EORI number is too long
 provideTraderEori.error.tooShort=EORI number is not long enough
 provideTraderEori.error.notGB=Enter EORI number beginning with GB
 provideTraderEori.error.specialCharacters=Enter an EORI number in the correct format, like GB123456789010
+provideTraderEori.error.default=Enter an EORI number in the correct format, like GB123456789010
 
 #TRADER DETAILS - COMMON
 traderDetails.common.searchAgain=<a href="{0}" class="govuk-link">Search again</a> if you think you entered the trader''s EORI number incorrectly.

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -203,7 +203,7 @@ provideTraderEori.error.required=Enter the trader''s EORI number
 provideTraderEori.error.tooLong=EORI number is too long
 provideTraderEori.error.tooShort=EORI number is not long enough
 provideTraderEori.error.notGB=Enter EORI number beginning with GB
-provideTraderEori.error.general=EORI country code can only be GB followed by 12 digits, like GB123456123456
+provideTraderEori.error.specialCharacters=Enter an EORI number in the correct format, like GB123456789010
 
 #TRADER DETAILS - COMMON
 traderDetails.common.searchAgain=<a href="{0}" class="govuk-link">Search again</a> if you think you entered the trader''s EORI number incorrectly.

--- a/test/controllers/ProvideTraderEoriControllerSpec.scala
+++ b/test/controllers/ProvideTraderEoriControllerSpec.scala
@@ -225,7 +225,7 @@ class ProvideTraderEoriControllerSpec extends SpecBase with MockitoSugar {
         }
       }
 
-      "value submitted otherwise fails the format constraints" in {
+      "value submitted contains special characters" in {
         val application =
           applicationBuilder(userAnswers = Some(userAnswersAsIndividualTrader))
             .build()
@@ -233,13 +233,13 @@ class ProvideTraderEoriControllerSpec extends SpecBase with MockitoSugar {
         running(application) {
           val request =
             FakeRequest(POST, provideTraderEoriPagePostRoute)
-              .withFormUrlEncodedBody(("value", "GB123ABC123123"))
+              .withFormUrlEncodedBody(("value", "GB1231231!!!!3"))
 
           val result = route(application, request).value
 
           val view      = application.injector.instanceOf[ProvideTraderEoriView]
           val boundForm =
-            form.bind(Map("value" -> "GB123ABC123123"))
+            form.bind(Map("value" -> "GB1231231!!!!3"))
 
           status(result) mustEqual BAD_REQUEST
           contentAsString(result) mustEqual view(boundForm, NormalMode, draftId)(

--- a/test/controllers/ProvideTraderEoriControllerSpec.scala
+++ b/test/controllers/ProvideTraderEoriControllerSpec.scala
@@ -248,6 +248,30 @@ class ProvideTraderEoriControllerSpec extends SpecBase with MockitoSugar {
           ).toString
         }
       }
+
+      "value does not otherwise match the format" in {
+        val application =
+          applicationBuilder(userAnswers = Some(userAnswersAsIndividualTrader))
+            .build()
+
+        running(application) {
+          val request =
+            FakeRequest(POST, provideTraderEoriPagePostRoute)
+              .withFormUrlEncodedBody(("value", "GB123123ABCABC"))
+
+          val result = route(application, request).value
+
+          val view      = application.injector.instanceOf[ProvideTraderEoriView]
+          val boundForm =
+            form.bind(Map("value" -> "GB123123ABCABC"))
+
+          status(result) mustEqual BAD_REQUEST
+          contentAsString(result) mustEqual view(boundForm, NormalMode, draftId)(
+            request,
+            messages(application)
+          ).toString
+        }
+      }
     }
 
     "must return invalidEoriView for a POST if provided EORI is not found" in {


### PR DESCRIPTION
fixed issue where supplied eori wasn't sent to backend
fixed issue where special characters weren't checked for correctly
preserved default error case (though using duplicate messaging)
improved default and special character case messaging