### PR TITLE
[FIX] - eori parameter missing from heading - put in

### DIFF
--- a/app/views/VerifyPublicTraderDetailView.scala.html
+++ b/app/views/VerifyPublicTraderDetailView.scala.html
@@ -55,7 +55,7 @@
     )
 }
 
-@layout(pageTitle = title(form, messages("traderDetails.public.heading")), draftId = Some(draftId)) {
+@layout(pageTitle = title(form, messages("traderDetails.public.heading", details.EORINo)), draftId = Some(draftId)) {
 
     @formHelper(action = controllers.routes.VerifyTraderEoriController.onSubmit(NormalMode, draftId)) {
 
@@ -64,7 +64,7 @@
         }
 
         @caption(messages("caption.applicant"))
-        <h1 class="govuk-heading-xl">@messages("traderDetails.public.heading")</h1>
+        <h1 class="govuk-heading-xl">@messages("traderDetails.public.heading", details.EORINo)</h1>
         <p class="govuk-body">@messages("traderDetails.public.p1")</p>
         <h3 class="govuk-heading-s">@messages("traderDetails.public.h3.businessName")</h3>
         <p class="govuk-body">@details.CDSFullName</p>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -861,7 +861,7 @@ traderDetails.common.searchAgain.link = Search again
 traderDetails.common.searchAgain = {0} if you think you entered the trader''s EORI number incorrectly.
 
 #TRADER DETAILS - PUBLIC
-traderDetails.public.heading=Check the name and address for EORI number
+traderDetails.public.heading=Check the name and address for EORI number {0}
 traderDetails.public.p1=These are the EORI details we have on record for the trader you are representing. They should be the same details the trader used to register their EORI number.
 traderDetails.public.h2.correct=EORI registration details
 traderDetails.public.h3.businessName=Registered business name

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -211,7 +211,7 @@ traderDetails.common.searchAgain.link = Search again
 traderDetails.common.searchAgain = {0} if you think you entered the trader''s EORI number incorrectly.
 
 #TRADER DETAILS - PUBLIC
-traderDetails.public.heading=Check the name and address for EORI number
+traderDetails.public.heading=Check the name and address for EORI number {0}
 traderDetails.public.p1=These are the EORI details we have on record for the trader you are representing. They should be the same details the trader used to register their EORI number.
 traderDetails.public.h2=EORI registration details
 traderDetails.public.h3.businessName=Registered business name


### PR DESCRIPTION
### Type of change
- [X] Cosmetic change

### Description
Message parameter was missing on this page where it should pull through the eori number of the details

### Attachments or Screenshots
![image](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/77161245/59f5a18e-9af9-4e3f-a058-61d80069e0c4)
![image](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/77161245/ce06ca42-fd2c-446b-b2c8-f9dfd4b3ac85)
