### PR TITLE
enforced that only positive confirmations go to letter of authority, …

### DIFF
--- a/app/controllers/VerifyTraderEoriController.scala
+++ b/app/controllers/VerifyTraderEoriController.scala
@@ -32,6 +32,7 @@ import models.{DraftId, Mode, TraderDetailsWithConfirmation}
 import navigation.Navigator
 import pages.VerifyTraderDetailsPage
 import services.UserAnswersService
+import userrole.UserRoleProvider
 import views.html.{VerifyPrivateTraderDetailView, VerifyPublicTraderDetailView}
 
 class VerifyTraderEoriController @Inject() (
@@ -44,7 +45,8 @@ class VerifyTraderEoriController @Inject() (
   formProvider: VerifyTraderDetailsFormProvider,
   val controllerComponents: MessagesControllerComponents,
   publicView: VerifyPublicTraderDetailView,
-  privateView: VerifyPrivateTraderDetailView
+  privateView: VerifyPrivateTraderDetailView,
+  userRoleProvider: UserRoleProvider
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport
@@ -104,11 +106,10 @@ class VerifyTraderEoriController @Inject() (
                         .set(details.copy(confirmation = Some(continue)))
                     _              <- userAnswersService.set(updatedAnswers)
                   } yield Redirect(
-                    (continue, details.consentToDisclosureOfPersonalData) match {
-                      case (true, _)      =>
-                        routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None)
-                      case (false, false) => ???
-                      case (false, true)  => ???
+                    if (continue) {
+                      routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None)
+                    } else {
+                      routes.EORIBeUpToDateController.onPageLoad(draftId)
                     }
                   )
               }

--- a/app/controllers/VerifyTraderEoriController.scala
+++ b/app/controllers/VerifyTraderEoriController.scala
@@ -97,15 +97,20 @@ class VerifyTraderEoriController @Inject() (
               VerifyTraderDetailsPage.get() match {
                 case None          => Future.successful(traderDetailsNotFoundInSession(draftId))
                 case Some(details) =>
+                  val continue = value.toBoolean
                   for {
                     updatedAnswers <-
                       VerifyTraderDetailsPage
-                        .set(details.copy(confirmation = Some(value.toBoolean)))
+                        .set(details.copy(confirmation = Some(continue)))
                     _              <- userAnswersService.set(updatedAnswers)
                   } yield Redirect(
-                    routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None)
+                    (continue, details.consentToDisclosureOfPersonalData) match {
+                      case (true, _)      =>
+                        routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None)
+                      case (false, false) => ???
+                      case (false, true)  => ???
+                    }
                   )
-
               }
           )
     }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -904,7 +904,7 @@ traderDetails.private.p1=The business this number is registered to has not conse
 traderDetails.private.p2=If you need more information, contact the business directly.
 traderDetails.private.h3.proceed=Do you want to proceed?
 
-verifyTraderDetails.error.required=Select yes to confirm the trader''s EORI details
+verifyTraderDetails.error.required=Select if you want to proceed with the application
 
 #INVALID EORI
 invalidTraderEori.heading=EORI number {0} is invalid

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -226,7 +226,7 @@ traderDetails.private.p1=The business this number is registered to has not conse
 traderDetails.private.p2=If you need more information, contact the business directly.
 traderDetails.private.h3.proceed=Do you want to proceed?
 
-verifyTraderDetails.error.required=Select yes to confirm the trader''s EORI details
+verifyTraderDetails.error.required=Select if you want to proceed with the application
 
 #INVALID EORI
 invalidTraderEori.heading = EORI number {0} is invalid

--- a/test/controllers/VerifyTraderEoriControllerSpec.scala
+++ b/test/controllers/VerifyTraderEoriControllerSpec.scala
@@ -229,9 +229,67 @@ class VerifyTraderEoriControllerSpec extends SpecBase with MockitoSugar {
       }
     }
 
-    "must redirect to ??? when public and unapproved" ignore {}
+    "must redirect to Kickout Page when public and unapproved" in {
+      val mockUserAnswersService = mock[UserAnswersService]
+      when(mockUserAnswersService.set(any())(any())).thenReturn(Future.successful(Done))
 
-    "must redirect to ??? when private and unapproved" ignore {}
+      val userAnswers = userAnswersAsIndividualTrader
+        .setFuture[TraderDetailsWithConfirmation](
+          VerifyTraderDetailsPage,
+          traderDetailsWithConfirmation.copy(consentToDisclosureOfPersonalData = true)
+        )
+        .futureValue
+
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswers))
+          .overrides(
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
+          )
+          .build()
+
+      running(application) {
+        val request = FakeRequest(POST, verifyTraderEoriPagePostRoute)
+          .withFormUrlEncodedBody(("traderDetailsCorrect", "false"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result) mustBe Some(
+          controllers.routes.EORIBeUpToDateController.onPageLoad(draftId).url
+        )
+      }
+    }
+
+    "must redirect to Kickout Page when private and unapproved" in {
+      val mockUserAnswersService = mock[UserAnswersService]
+      when(mockUserAnswersService.set(any())(any())).thenReturn(Future.successful(Done))
+
+      val userAnswers = userAnswersAsIndividualTrader
+        .setFuture[TraderDetailsWithConfirmation](
+          VerifyTraderDetailsPage,
+          traderDetailsWithConfirmation.copy(consentToDisclosureOfPersonalData = true)
+        )
+        .futureValue
+
+      val application =
+        applicationBuilder(userAnswers = Some(userAnswers))
+          .overrides(
+            bind[UserAnswersService].toInstance(mockUserAnswersService)
+          )
+          .build()
+
+      running(application) {
+        val request = FakeRequest(POST, verifyTraderEoriPagePostRoute)
+          .withFormUrlEncodedBody(("traderDetailsCorrect", "false"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result) mustBe Some(
+          controllers.routes.EORIBeUpToDateController.onPageLoad(draftId).url
+        )
+      }
+    }
 
     "must display an error on the page when no selection is made - public" in {
 


### PR DESCRIPTION
…and updated error message when no input given to verifytradereoricontroller

### Type of change
- [X] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Agent select "Yes" to proceed with a Private EORI](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-200)

Corrected Error Message
Enforced that *ONLY* inputting a yes will proceed to UploadLetterOfAuthorityController, no's will return ??? until those tickets are completed
Added tests (and empty tests) to enforce the above