### PR TITLE
ARSSTB-227/306 Hidden text fix.

### DIFF
--- a/app/views/UploadAnotherSupportingDocumentView.scala.html
+++ b/app/views/UploadAnotherSupportingDocumentView.scala.html
@@ -23,7 +23,6 @@
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
     govukTable: GovukTable,
-    govukLink: Link,
     caption: Caption,
     heading: Heading,
     subheading: Subheading,
@@ -54,6 +53,13 @@
     attachments.length
 }
 
+@removeLink(i: Int) = {
+    <a id="@{"remove-file-" + i}" href="@controllers.routes.RemoveSupportingDocumentController.onPageLoad(mode, draftId, Index(i)).url">
+        @messages("site.remove")
+        <span class="govuk-visually-hidden">remove this document from your list of supporting documents</span>
+    </a>
+}
+
 @layout(pageTitle = title(form, titleMessage), draftId = Some(draftId)) {
 
     @formHelper(action = routes.UploadAnotherSupportingDocumentController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
@@ -72,14 +78,7 @@
               TableRow(content = Text(attachment.file.fileName.getOrElse(""))),
               TableRow(content = Text(if(attachment.isThisFileConfidential.contains(true)) messages("uploadAnotherSupportingDocument.keepConfidential") else "")),
               TableRow(
-                HtmlContent(
-                  govukLink(
-                    id = "remove-file-" + i,
-                    text = messages("site.remove"),
-                    call = controllers.routes.RemoveSupportingDocumentController.onPageLoad(mode, draftId, Index(i)),
-                    newTab = false
-                  )
-                )
+                HtmlContent(removeLink(i))
               )
             )
           },

--- a/app/views/UploadAnotherSupportingDocumentView.scala.html
+++ b/app/views/UploadAnotherSupportingDocumentView.scala.html
@@ -56,7 +56,7 @@
 @removeLink(i: Int) = {
     <a id="@{"remove-file-" + i}" href="@controllers.routes.RemoveSupportingDocumentController.onPageLoad(mode, draftId, Index(i)).url">
         @messages("site.remove")
-        <span class="govuk-visually-hidden">remove this document from your list of supporting documents</span>
+        <span class="govuk-visually-hidden">@messages("supportingDocuments.remove.hidden")</span>
     </a>
 }
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -926,3 +926,5 @@ yourApplicationHasBeenCancelled.heading = You cannot view this application
 yourApplicationHasBeenCancelled.paragraph.1 = This is because you cancelled your application for an Advance Valuation Ruling. The data you submitted before has been deleted.
 yourApplicationHasBeenCancelled.paragraph.2 = You can start a new application if you wish to do so.
 yourApplicationHasBeenCancelled.button = Go to your applications and rulings
+
+supportingDocuments.remove.hidden = remove this document from your list of supporting documents

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -928,3 +928,5 @@ yourApplicationHasBeenCancelled.heading = You cannot view this application
 yourApplicationHasBeenCancelled.paragraph.1 = This is because you cancelled your application for an Advance Valuation Ruling. The data you submitted before has been deleted.
 yourApplicationHasBeenCancelled.paragraph.2 = You can start a new application if you wish to do so.
 yourApplicationHasBeenCancelled.button = Go to your applications and rulings
+
+supportingDocuments.remove.hidden = remove this document from your list of supporting documents


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [ARSSTB-227](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-227)
Spike link: [ARSSTB-306](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-306)

Solves the issue of missing hidden text on the file removal links.

I was unable to recreate the issue for the change links on CheckYourAnswers as it seems they DO have hidden text, but it may be wrong - it seems like that needs revisiting or a discussion. See the messages file for any lines that contain: change.hidden