### PR TITLE
Fix failing UI tests

### DIFF
--- a/app/controllers/EORIBeUpToDateController.scala
+++ b/app/controllers/EORIBeUpToDateController.scala
@@ -45,16 +45,15 @@ class EORIBeUpToDateController @Inject() (
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
         if (appConfig.agentOnBehalfOfTrader) {
-          VerifyTraderDetailsPage.get() match {
-            case Some(details) =>
-              Ok(
-                userRoleProvider
-                  .getUserRole(request.userAnswers)
-                  .selectViewForEoriBeUpToDate(draftId, !details.consentToDisclosureOfPersonalData)
-              )
-            case None          =>
-              Redirect(routes.JourneyRecoveryController.onPageLoad())
+          val isPrivate = VerifyTraderDetailsPage.get() match {
+            case Some(details) => !details.consentToDisclosureOfPersonalData
+            case _             => true
           }
+          Ok(
+            userRoleProvider
+              .getUserRole(request.userAnswers)
+              .selectViewForEoriBeUpToDate(draftId, isPrivate)
+          )
         } else {
           AccountHomePage.get() match {
             case None               =>


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Regression bug: Journey for 'Employee' and 'Agent of Org' journey is broken](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-353)

Assume that the user does not consent to disclose personal data unless they select the agent for trader role. In this case, check their consent. The journey recovery page has been removed since the page should be displayed in all cases.

### Attachments or Screenshots
Employee role:
![Screenshot 2023-08-18 at 15 46 10](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/4c1650df-393d-4c60-bf7b-2195c53582b2)
Agent for organisation role:
![Screenshot 2023-08-18 at 15 46 44](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/8ff612a9-bc69-4469-9a76-1f1456eedbc6)
Agent for trader role:
![Screenshot 2023-08-18 at 15 47 08](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/93401a25-5557-4f48-9ad4-681af84e995d)