### PR TITLE
feat: add save as draft button for upload letter of authority view

### DIFF
--- a/app/views/UploadLetterOfAuthorityView.scala.html
+++ b/app/views/UploadLetterOfAuthorityView.scala.html
@@ -142,16 +142,22 @@
     <div class="govuk-button-group">
       @govukButton(
         ButtonViewModel(
-        messages("uploadLetterOfAuthority.button")
+          messages("uploadLetterOfAuthority.button")
         )
-                .preventingDoubleClick()
-                .withAttribute(("id" -> "submit"))
-                .disableIf(shouldRefresh)
+        .preventingDoubleClick()
+        .withAttribute(("id" -> "submit"))
+        .disableIf(shouldRefresh)
       )
 
-      <a href="@routes.DraftHasBeenSavedController.onPageLoad(draftId).url" role="button" class="govuk-button govuk-button--secondary">
-        @messages("site.saveAsDraft")
-      </a>
+      @govukButton(
+        ButtonViewModel(
+          messages("site.saveAsDraft")
+        )
+        .asSecondaryButton()
+        .asLink(routes.DraftHasBeenSavedController.onPageLoad(draftId).url)
+        .preventingDoubleClick()
+        .disableIf(shouldRefresh)
+      )
     </div>
   }
 

--- a/app/views/UploadLetterOfAuthorityView.scala.html
+++ b/app/views/UploadLetterOfAuthorityView.scala.html
@@ -148,6 +148,10 @@
                 .withAttribute(("id" -> "submit"))
                 .disableIf(shouldRefresh)
       )
+
+      <a href="@routes.DraftHasBeenSavedController.onPageLoad(draftId).url" role="button" class="govuk-button govuk-button--secondary">
+        @messages("site.saveAsDraft")
+      </a>
     </div>
   }
 


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Add Save as draft button to Upload Letter of Authority Page](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-326)

Add save as draft button for upload letter of authority view.

### Attachments or Screenshots
![Screenshot 2023-08-21 at 16 13 47](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/6dba7e38-7f77-428e-a5c6-7e889919aeed)
