### PR TITLE
added checkmode support and routes for upload letter of authority pages

### DIFF
--- a/app/controllers/UploadLetterOfAuthorityController.scala
+++ b/app/controllers/UploadLetterOfAuthorityController.scala
@@ -49,12 +49,13 @@ class UploadLetterOfAuthorityController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  private val mode: Mode                       = NormalMode // TODO: allow other modes other than NormalMode.
+//  private val mode: Mode                       = NormalMode // TODO: allow other modes other than NormalMode.
   private val maxFileSize: Long                = configuration.underlying.getBytes("upscan.maxFileSize") / 1000000L
   private val controller                       = controllers.routes.UploadLetterOfAuthorityController
   private val page: QuestionPage[UploadedFile] = UploadLetterOfAuthorityPage
 
   def onPageLoad(
+    mode: Mode,
     draftId: DraftId,
     errorCode: Option[String],
     key: Option[String]
@@ -63,7 +64,7 @@ class UploadLetterOfAuthorityController @Inject() (
       implicit request =>
         val redirectPath =
           controller
-            .onPageLoad(draftId, None, None)
+            .onPageLoad(mode, draftId, None, None)
             .url // redirect probably shouldn't have the errorCode in it
         val answers      = request.userAnswers
 
@@ -95,6 +96,7 @@ class UploadLetterOfAuthorityController @Inject() (
               }
             case file: UploadedFile.Failure   =>
               redirectWithError(
+                mode,
                 draftId,
                 key,
                 file.failureDetails.failureReason.toString,
@@ -151,13 +153,14 @@ class UploadLetterOfAuthorityController @Inject() (
     }
 
   private def redirectWithError(
+    mode: Mode,
     draftId: DraftId,
     key: Option[String],
     errorCode: String,
     redirectPath: String
   )(implicit request: RequestHeader): Future[Result] =
     fileService.initiate(draftId, redirectPath, isLetterOfAuthority = true).map {
-      _ => Redirect(controller.onPageLoad(draftId, Some(errorCode), key))
+      _ => Redirect(controller.onPageLoad(mode, draftId, Some(errorCode), key))
     }
 
   private def continue(mode: Mode, answers: UserAnswers): Future[Result] =

--- a/app/controllers/VerifyLetterOfAuthorityController.scala
+++ b/app/controllers/VerifyLetterOfAuthorityController.scala
@@ -43,19 +43,19 @@ class VerifyLetterOfAuthorityController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad(draftId: DraftId): Action[AnyContent] =
+  def onPageLoad(mode: Mode, draftId: DraftId): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
         UploadLetterOfAuthorityPage.get() match {
-          case Some(attachment) => Ok(view(attachment, draftId))
+          case Some(attachment) => Ok(view(attachment, draftId, mode))
           case None             => Redirect(JourneyRecoveryController.onPageLoad())
         }
 
     }
 
-  def onSubmit(draftId: DraftId): Action[AnyContent] =
+  def onSubmit(mode: Mode, draftId: DraftId): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
-        Redirect(navigator.nextPage(VerifyLetterOfAuthorityPage, NormalMode, request.userAnswers))
+        Redirect(navigator.nextPage(VerifyLetterOfAuthorityPage, mode, request.userAnswers))
     }
 }

--- a/app/controllers/VerifyTraderEoriController.scala
+++ b/app/controllers/VerifyTraderEoriController.scala
@@ -107,7 +107,7 @@ class VerifyTraderEoriController @Inject() (
                     _              <- userAnswersService.set(updatedAnswers)
                   } yield Redirect(
                     if (continue) {
-                      routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None)
+                      routes.UploadLetterOfAuthorityController.onPageLoad(mode, draftId, None, None)
                     } else {
                       routes.EORIBeUpToDateController.onPageLoad(draftId)
                     }

--- a/app/navigation/CheckModeNavigator.scala
+++ b/app/navigation/CheckModeNavigator.scala
@@ -126,6 +126,9 @@ object CheckModeNavigator {
       }
       .getOrElse(JourneyRecoveryController.onPageLoad())
 
+  private def uploadLetterOfAuthority(userAnswers: UserAnswers): Call =
+    VerifyLetterOfAuthorityController.onPageLoad(CheckMode, userAnswers.draftId)
+
   private def removeSupportingDocumentPage(userAnswers: UserAnswers): Call = {
     val numberOfDocuments = userAnswers.get(AllDocuments).map(_.size)
 
@@ -322,6 +325,9 @@ object CheckModeNavigator {
       case UploadAnotherSupportingDocumentPage          => uploadAnotherSupportingDocument(userAnswers)
       case WhatIsYourRoleAsImporterPage                 => whatIsYourRoleAsImporter(userAnswers)
       case RemoveSupportingDocumentPage(_)              => removeSupportingDocumentPage(userAnswers)
+
+      // agent
+      case UploadLetterOfAuthorityPage => uploadLetterOfAuthority(userAnswers)
 
       // method 1
       case IsThereASaleInvolvedPage           => isThereASaleInvolved(userAnswers)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -86,7 +86,7 @@ class Navigator @Inject() (appConfig: FrontendAppConfig, userRoleProvider: UserR
     case AdaptMethodPage                                  => adaptMethodPage
     case DeleteDraftPage                                  => _ => AccountHomeController.onPageLoad()
     case AgentForTraderCheckRegisteredDetailsPage         =>
-      ua => UploadLetterOfAuthorityController.onPageLoad(ua.draftId, None, None)
+      ua => UploadLetterOfAuthorityController.onPageLoad(NormalMode, ua.draftId, None, None)
     case AgentForOrgCheckRegisteredDetailsPage            =>
       ua => BusinessContactDetailsController.onPageLoad(NormalMode, ua.draftId)
     case AgentForOrgApplicationContactDetailsPage         =>
@@ -545,7 +545,7 @@ class Navigator @Inject() (appConfig: FrontendAppConfig, userRoleProvider: UserR
     }
 
   private def uploadLetterOfAuthorityPage(userAnswers: UserAnswers): Call =
-    VerifyLetterOfAuthorityController.onPageLoad(userAnswers.draftId)
+    VerifyLetterOfAuthorityController.onPageLoad(NormalMode, userAnswers.draftId)
 
   private def verifyLetterOfAuthorityPage(userAnswers: UserAnswers): Call =
     BusinessContactDetailsController.onPageLoad(NormalMode, userAnswers.draftId)

--- a/app/views/VerifyLetterOfAuthorityView.scala.html
+++ b/app/views/VerifyLetterOfAuthorityView.scala.html
@@ -31,7 +31,7 @@
     saveButtons: SaveButtons
 )
 
-@(attachment: UploadedFile, draftId: DraftId)(implicit request: Request[_], messages: Messages)
+@(attachment: UploadedFile, draftId: DraftId, mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @titleMessage = @{messages("verifyLetterOfAuthority.title")}
 
@@ -39,7 +39,7 @@
 
 @layout(pageTitle = titleNoForm(titleMessage), draftId = Some(draftId)) {
 
-    @formHelper(action = routes.VerifyLetterOfAuthorityController.onSubmit(draftId), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.VerifyLetterOfAuthorityController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
 
         @caption(messages("verifyLetterOfAuthority.caption"))
 
@@ -57,7 +57,7 @@
                 @link(
                     id = "change",
                     text = messages("site.change"),
-                    call = controllers.routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None),
+                    call = controllers.routes.UploadLetterOfAuthorityController.onPageLoad(mode, draftId, None, None),
                     newTab = false,
                     hiddenText = true,
                     hiddenTextContent =  messages("verifyLetterOfAuthority.hiddenText", attachment.fileName.getOrElse(""))

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -254,9 +254,13 @@ POST       /:draftId/supporting-documents/:index/change-remove                  
 
 GET        /:draftId/save-as-draft                       controllers.DraftHasBeenSavedController.onPageLoad(draftId: DraftId)
 
-GET        /:draftId/ars-upload-loa                     controllers.UploadLetterOfAuthorityController.onPageLoad(draftId: DraftId, errorCode: Option[String], key: Option[String])
+GET        /:draftId/ars-upload-loa                     controllers.UploadLetterOfAuthorityController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
+GET        /:draftId/ars-change-loa                    controllers.UploadLetterOfAuthorityController.onPageLoad(mode: Mode = CheckMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
 
-GET        /:draftId/ars-loa-uploaded                   controllers.VerifyLetterOfAuthorityController.onPageLoad(draftId: DraftId)
-POST       /:draftId/ars-loa-uploaded                   controllers.VerifyLetterOfAuthorityController.onSubmit(draftId: DraftId)
+GET        /:draftId/ars-upload-loa-uploaded                   controllers.VerifyLetterOfAuthorityController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId)
+GET        /:draftId/ars-change-loa-uploaded                   controllers.VerifyLetterOfAuthorityController.onPageLoad(mode: Mode = CheckMode, draftId: DraftId)
+
+POST       /:draftId/ars-upload-loa-uploaded                   controllers.VerifyLetterOfAuthorityController.onSubmit(mode: Mode = NormalMode, draftId: DraftId)
+POST       /:draftId/ars-change-loa-uploaded                   controllers.VerifyLetterOfAuthorityController.onSubmit(mode: Mode = CheckMode, draftId: DraftId)
 
 GET        /application-cancelled                       controllers.YourApplicationHasBeenCancelledController.onPageLoad()

--- a/test/controllers/CheckRegisteredDetailsControllerSpec.scala
+++ b/test/controllers/CheckRegisteredDetailsControllerSpec.scala
@@ -216,7 +216,7 @@ class CheckRegisteredDetailsControllerSpec
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual routes.UploadLetterOfAuthorityController
-          .onPageLoad(draftId, None, None)
+          .onPageLoad(NormalMode, draftId, None, None)
           .url
       }
     }

--- a/test/controllers/UploadLetterOfAuthorityControllerSpec.scala
+++ b/test/controllers/UploadLetterOfAuthorityControllerSpec.scala
@@ -28,7 +28,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 
 import base.SpecBase
-import models.UploadedFile
+import models.{NormalMode, UploadedFile}
 import models.upscan.UpscanInitiateResponse
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
@@ -58,7 +58,7 @@ class UploadLetterOfAuthorityControllerSpec
   private val controller                           = controllers.routes.UploadLetterOfAuthorityController
   private lazy val redirectPath: String            =
     controllers.routes.UploadLetterOfAuthorityController
-      .onPageLoad(draftId, None, None)
+      .onPageLoad(NormalMode, draftId, None, None)
       .url
   private val page                                 = UploadLetterOfAuthorityPage
   private def injectView(application: Application) =
@@ -123,7 +123,7 @@ class UploadLetterOfAuthorityControllerSpec
 
       val request = FakeRequest(
         GET,
-        controller.onPageLoad(draftId, None, None).url
+        controller.onPageLoad(NormalMode, draftId, None, None).url
       )
 
       val result = route(application, request).value
@@ -155,7 +155,7 @@ class UploadLetterOfAuthorityControllerSpec
 
           val request = FakeRequest(
             GET,
-            controller.onPageLoad(draftId, None, Some("reference")).url
+            controller.onPageLoad(NormalMode, draftId, None, Some("reference")).url
           )
 
           val result = route(application, request).value
@@ -183,7 +183,7 @@ class UploadLetterOfAuthorityControllerSpec
 
           val request = FakeRequest(
             GET,
-            controller.onPageLoad(draftId, None, Some("otherReference")).url
+            controller.onPageLoad(NormalMode, draftId, None, Some("otherReference")).url
           )
 
           val result = route(application, request).value
@@ -212,7 +212,7 @@ class UploadLetterOfAuthorityControllerSpec
           val request = FakeRequest(
             GET,
             controller
-              .onPageLoad(draftId, None, None)
+              .onPageLoad(NormalMode, draftId, None, None)
               .url
           )
 
@@ -250,7 +250,7 @@ class UploadLetterOfAuthorityControllerSpec
 
         val request = FakeRequest(
           GET,
-          controller.onPageLoad(draftId, None, Some(successfulFile.reference)).url
+          controller.onPageLoad(NormalMode, draftId, None, Some(successfulFile.reference)).url
         )
 
         val result = route(application, request).value
@@ -274,7 +274,7 @@ class UploadLetterOfAuthorityControllerSpec
 
         val request = FakeRequest(
           GET,
-          controller.onPageLoad(draftId, None, Some("otherReference")).url
+          controller.onPageLoad(NormalMode, draftId, None, Some("otherReference")).url
         )
 
         val result = route(application, request).value
@@ -303,7 +303,7 @@ class UploadLetterOfAuthorityControllerSpec
         val request = FakeRequest(
           GET,
           controller
-            .onPageLoad(draftId, None, None)
+            .onPageLoad(NormalMode, draftId, None, None)
             .url
         )
 
@@ -330,7 +330,7 @@ class UploadLetterOfAuthorityControllerSpec
     val request = FakeRequest(
       GET,
       controller
-        .onPageLoad(draftId, None, None)
+        .onPageLoad(NormalMode, draftId, None, None)
         .url
     )
 
@@ -414,14 +414,14 @@ class UploadLetterOfAuthorityControllerSpec
 
           val request = FakeRequest(
             GET,
-            controller.onPageLoad(draftId, None, Some("key")).url
+            controller.onPageLoad(NormalMode, draftId, None, Some("key")).url
           )
 
           val result = route(application, request).value
 
           status(result) mustEqual SEE_OTHER
           redirectLocation(result).value mustEqual controller
-            .onPageLoad(draftId, Some(errCode), Some("key"))
+            .onPageLoad(NormalMode, draftId, Some(errCode), Some("key"))
             .url
       }
     }
@@ -448,7 +448,7 @@ class UploadLetterOfAuthorityControllerSpec
           val request = FakeRequest(
             GET,
             controller
-              .onPageLoad(draftId, Some(errCode), None)
+              .onPageLoad(NormalMode, draftId, Some(errCode), None)
               .url
           )
 

--- a/test/controllers/VerifyLetterOfAuthorityControllerSpec.scala
+++ b/test/controllers/VerifyLetterOfAuthorityControllerSpec.scala
@@ -27,7 +27,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, redirectLocation, route, status, writeableOf_AnyContentAsEmpty, GET}
 
 import base.SpecBase
-import models.{UploadedFile, UserAnswers}
+import models.{NormalMode, UploadedFile, UserAnswers}
 import models.WhatIsYourRoleAsImporter.AgentOnBehalfOfTrader
 import org.scalatestplus.mockito.MockitoSugar
 import pages.{UploadLetterOfAuthorityPage, WhatIsYourRoleAsImporterPage}
@@ -36,7 +36,7 @@ import views.html.VerifyLetterOfAuthorityView
 class VerifyLetterOfAuthorityControllerSpec extends SpecBase with MockitoSugar {
 
   private lazy val verifyLetterOfAuthorityRoute =
-    routes.VerifyLetterOfAuthorityController.onPageLoad(draftId).url
+    routes.VerifyLetterOfAuthorityController.onPageLoad(NormalMode, draftId).url
 
   private val uploadedFile = UploadedFile.Success(
     reference = "reference",
@@ -70,7 +70,7 @@ class VerifyLetterOfAuthorityControllerSpec extends SpecBase with MockitoSugar {
       val view                   = application.injector.instanceOf[VerifyLetterOfAuthorityView]
 
       status(result) mustEqual OK
-      contentAsString(result) mustEqual view(uploadedFile, draftId)(
+      contentAsString(result) mustEqual view(uploadedFile, draftId, NormalMode)(
         request,
         messages(application)
       ).toString

--- a/test/controllers/VerifyTraderEoriControllerSpec.scala
+++ b/test/controllers/VerifyTraderEoriControllerSpec.scala
@@ -193,7 +193,9 @@ class VerifyTraderEoriControllerSpec extends SpecBase with MockitoSugar {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result) mustBe Some(
-          controllers.routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None).url
+          controllers.routes.UploadLetterOfAuthorityController
+            .onPageLoad(NormalMode, draftId, None, None)
+            .url
         )
       }
     }
@@ -224,7 +226,9 @@ class VerifyTraderEoriControllerSpec extends SpecBase with MockitoSugar {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result) mustBe Some(
-          controllers.routes.UploadLetterOfAuthorityController.onPageLoad(draftId, None, None).url
+          controllers.routes.UploadLetterOfAuthorityController
+            .onPageLoad(NormalMode, draftId, None, None)
+            .url
         )
       }
     }


### PR DESCRIPTION
### Type of change
- [X] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Letter of Authority page should allow Check Mode](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-320)

Added support for passing the mode through the various controllers.

Cannot manually test via check your answers due to work involved in ARSSTB-352. You have to use the manual route, but that works correctly (see routes added to routes file)

May be worth considering additional unit tests regarding the checkmode route, I leave that to you guys
