### PR TITLE
230: Remove bold subheading label from the explain why method 4 page

### DIFF
--- a/app/views/ExplainWhyYouChoseMethodFourView.scala.html
+++ b/app/views/ExplainWhyYouChoseMethodFourView.scala.html
@@ -53,7 +53,6 @@
 
     @paragraph(Html(messages("explainWhyYouChoseMethodFour.paragraph.3")))
 
-    @subheading(messages("explainWhyYouChoseMethodFour.label"))
     @govukTextarea(
         TextareaViewModel(
             field = form("value"),


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non-breaking change
- [x] Cosmetic change

### Description
Jira link: [Unhelpful hint text](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-230)

Revert a previous change which added a bold subheading label for the explain why method 4 page.

### Attachments or Screenshots
![Screenshot 2023-08-30 at 16 28 03](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/0efe47f7-f2f5-43e0-b5ab-ce06d032145f)
