### PR TITLE
fix: change maximum phone number length from 25 to 24

### DIFF
--- a/app/forms/Validation.scala
+++ b/app/forms/Validation.scala
@@ -21,7 +21,7 @@ import scala.util.matching.Regex
 object Validation {
 
   val nameMaxLength        = 70
-  val phoneNumberMaxLength = 25
+  val phoneNumberMaxLength = 24
   val emailMaxLength       = 50
 
   val nameInputPattern: Regex = "[A-Za-zÀ-ÖØ-öø-ÿĀ-ňŊ-ſ'’ -]+".r.anchored


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Bug - Agent for trader - Incorrect error messages displayed for telephone number field](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-383)

This bug was initially intended to fix two issues:
1) Only allow 1 error message per input field.
2) Reduce the maximum allowed phone number length from 25 to 24.

After further discussions (see bug comments) requirement 1 has been dropped.

### Attachments or Screenshots
![phone number error for 25 numbers](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/402f80d2-78c4-4d8c-9b53-180696a8b6c3)
![no phone number error for 24 numbers](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/54d49a00-a9d9-446e-bcd1-4f7f83e0d401)
