### PR TITLE
Arsstb 394 upload atomicity

### DIFF
--- a/app/controllers/IsThisFileConfidentialController.scala
+++ b/app/controllers/IsThisFileConfidentialController.scala
@@ -80,8 +80,9 @@ class IsThisFileConfidentialController @Inject() (
               UploadSupportingDocumentPage.get() match {
                 case Some(file: UploadedFile.Success) =>
                   val allDocuments = AllDocuments.get().getOrElse(List.empty[DraftAttachment])
-                  val draft        = DraftAttachment(file, Some(value))
-                  val documents    = allDocuments :+ draft
+
+                  val draft     = DraftAttachment(file, Some(value))
+                  val documents = allDocuments :+ draft
 
                   for {
                     ua <- AllDocuments.set(documents)

--- a/app/controllers/IsThisFileConfidentialController.scala
+++ b/app/controllers/IsThisFileConfidentialController.scala
@@ -55,17 +55,16 @@ class IsThisFileConfidentialController @Inject() (
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
         lazy val isSuccessful =
-          UploadSupportingDocumentPage.get().map(_.isSuccessful).getOrElse(false)
+          UploadSupportingDocumentPage.get().exists(_.isSuccessful)
 
-        isSuccessful match {
-          case true  =>
-            val preparedForm = IsThisFileConfidentialPage.fill(form)
-            Ok(view(preparedForm, mode, draftId))
-          case false =>
-            Redirect(
-              routes.UploadSupportingDocumentsController
-                .onPageLoad(mode, request.userAnswers.draftId, None, None)
-            )
+        if (isSuccessful) {
+          val preparedForm = IsThisFileConfidentialPage.fill(form)
+          Ok(view(preparedForm, mode, draftId))
+        } else {
+          Redirect(
+            routes.UploadSupportingDocumentsController
+              .onPageLoad(mode, request.userAnswers.draftId, None, None)
+          )
         }
     }
 

--- a/app/controllers/UploadInProgressController.scala
+++ b/app/controllers/UploadInProgressController.scala
@@ -48,8 +48,8 @@ class UploadInProgressController @Inject() (
         val answers = request.userAnswers
         val status  = helper.checkForStatus(answers, UploadSupportingDocumentPage).get
         status match {
-          case file: UploadedFile.Success =>
-            Await.result(helper.removeFile(NormalMode, draftId, file.fileUrl.get), 1.seconds)
+          case file: UploadedFile.Success =>  // TODO: WIP
+            Await.result(helper.removeFile(NormalMode, draftId, file.fileUrl.get), 100.seconds)
           case _                          =>
             Ok(view(draftId, key))
         }

--- a/app/controllers/UploadInProgressController.scala
+++ b/app/controllers/UploadInProgressController.scala
@@ -18,6 +18,9 @@ package controllers
 
 import javax.inject.Inject
 
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -46,7 +49,7 @@ class UploadInProgressController @Inject() (
         val status  = helper.checkForStatus(answers, UploadSupportingDocumentPage).get
         status match {
           case file: UploadedFile.Success =>
-            helper.removeFile(NormalMode, draftId, file.fileUrl.get)
+            Await.result(helper.removeFile(NormalMode, draftId, file.fileUrl.get), 1.seconds)
           case _                          =>
             Ok(view(draftId, key))
         }

--- a/app/controllers/UploadInProgressController.scala
+++ b/app/controllers/UploadInProgressController.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import controllers.actions._
 import controllers.common.FileUploadHelper
-import models.{DraftId, Mode, NormalMode, UploadedFile}
+import models.{DraftId, Mode, UploadedFile}
 import pages.UploadSupportingDocumentPage
 import views.html.UploadInProgressView
 

--- a/app/controllers/UploadInProgressController.scala
+++ b/app/controllers/UploadInProgressController.scala
@@ -42,7 +42,7 @@ class UploadInProgressController @Inject() (
 ) extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad(draftId: DraftId, key: Option[String]): Action[AnyContent] =
+  def onPageLoad(mode: Mode, draftId: DraftId, key: Option[String]): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
         val answers = request.userAnswers
@@ -51,12 +51,12 @@ class UploadInProgressController @Inject() (
           case Some(file) =>
             file match {
               case file: UploadedFile.Success =>
-                Await.result(helper.removeFile(NormalMode, draftId, file.fileUrl.get), 100.seconds)
+                Await.result(helper.removeFile(mode, draftId, file.fileUrl.get), 3.seconds)
               case _                          =>
-                Ok(view(draftId, key))
+                Ok(view(mode, draftId, key))
             }
           case _          =>
-            Ok(view(draftId, key))
+            Ok(view(mode, draftId, key))
         }
     }
 

--- a/app/controllers/UploadInProgressController.scala
+++ b/app/controllers/UploadInProgressController.scala
@@ -46,10 +46,7 @@ class UploadInProgressController @Inject() (
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
         val answers = request.userAnswers
-        val status  = helper.checkForStatus(
-          answers,
-          UploadSupportingDocumentPage
-        ) // .getOrElse(UploadedFile.Initiated)
+        val status  = helper.checkForStatus(answers, UploadSupportingDocumentPage)
         status match {
           case Some(file) =>
             file match {

--- a/app/controllers/UploadSupportingDocumentsController.scala
+++ b/app/controllers/UploadSupportingDocumentsController.scala
@@ -69,7 +69,8 @@ class UploadSupportingDocumentsController @Inject() (
                     helper.showFallbackPage(mode, draftId, isLetterOfAuthority = false)
                   }
                 }
-
+            case file: UploadedFile.Success   =>
+              helper.removeFile(mode, draftId, file.fileUrl.get)
           }
           .getOrElse {
             helper.showFallbackPage(mode, draftId, isLetterOfAuthority = false)

--- a/app/controllers/common/FileUploadHelper.scala
+++ b/app/controllers/common/FileUploadHelper.scala
@@ -27,12 +27,10 @@ import uk.gov.hmrc.objectstore.client.Path
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
-import controllers.ModifiableOps
-import models.{DraftId, Index, Mode, NormalMode, UploadedFile, UserAnswers}
+import models.{DraftId, Mode, NormalMode, UploadedFile, UserAnswers}
 import models.requests.DataRequest
 import navigation.Navigator
 import pages.{Page, QuestionPage}
-import queries.{AllDocuments, DraftAttachmentAt, DraftAttachmentQuery}
 import services.UserAnswersService
 import services.fileupload.FileService
 import views.html.{UploadLetterOfAuthorityView, UploadSupportingDocumentsView}
@@ -82,7 +80,7 @@ case class FileUploadHelper @Inject() (
     request: DataRequest[AnyContent]
   ): Future[Result] = {
     osClient.deleteObject(Path.File(fileUrl))
-    showFallbackPage(mode, draftId, false)
+    showFallbackPage(mode, draftId, isLetterOfAuthority = false)
   }
 
   def showInProgressPage(

--- a/app/controllers/common/FileUploadHelper.scala
+++ b/app/controllers/common/FileUploadHelper.scala
@@ -168,7 +168,8 @@ case class FileUploadHelper @Inject() (
         navigator.nextPage(page, mode, answers)
       )
     )
-  def errorForCode(code: String)(implicit messages: Messages): String        =
+
+  def errorForCode(code: String)(implicit messages: Messages): String =
     code match {
       case "InvalidArgument" =>
         Messages("fileUpload.error.invalidargument")

--- a/app/views/UploadInProgressView.scala.html
+++ b/app/views/UploadInProgressView.scala.html
@@ -25,7 +25,7 @@
         cancelLink: CancelApplicationLink
 )
 
-@(draftId:DraftId, key: Option[String])(implicit messages: Messages, request: Request[_])
+@(mode: Mode, draftId: DraftId, key: Option[String])(implicit messages: Messages, request: Request[_])
 
 @layout(pageTitle = titleNoForm(messages("uploadInProgress.title")), showBackLink = false) {
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -265,5 +265,5 @@ GET        /application-cancelled                       controllers.YourApplicat
 GET        /:draftId/supporting-documents/upload                                  controllers.UploadSupportingDocumentsController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
 GET        /:draftId/supporting-documents/change-upload                           controllers.UploadSupportingDocumentsController.onPageLoad(mode: Mode = CheckMode, draftId: DraftId, errorCode: Option[String], key: Option[String])
 
-GET        /:draftId/upload-in-progress                       controllers.UploadInProgressController.onPageLoad(draftId: DraftId, key: Option[String])
+GET        /:draftId/upload-in-progress                       controllers.UploadInProgressController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId, key: Option[String])
 POST       /:draftId/upload-in-progress                       controllers.UploadInProgressController.checkProgress(mode: Mode = NormalMode, draftId: DraftId, key: Option[String])

--- a/test/controllers/UploadInProgressControllerSpec.scala
+++ b/test/controllers/UploadInProgressControllerSpec.scala
@@ -114,24 +114,31 @@ class UploadInProgressControllerSpec extends SpecBase with MockitoSugar with Bef
 
   "UploadInProgress Controller" - {
 
-    "must return OK and the correct view for a GET" in {
+    "On page load" - {
 
-      val application =
-        applicationBuilder(userAnswers = Some(userAnswersAsIndividualTrader)).build()
+      "must return OK and the correct view by default" in {
 
-      running(application) {
-        val request =
-          FakeRequest(GET, routes.UploadInProgressController.onPageLoad(draftId, None).url)
+        val application =
+          applicationBuilder(userAnswers = Some(userAnswersAsIndividualTrader)).build()
 
-        val result = route(application, request).value
+        running(application) {
+          val request =
+            FakeRequest(GET, routes.UploadInProgressController.onPageLoad(draftId, None).url)
 
-        val view = application.injector.instanceOf[UploadInProgressView]
+          val result = route(application, request).value
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view(draftId, None)(
-          messages(application),
-          request
-        ).toString
+          val view = application.injector.instanceOf[UploadInProgressView]
+
+          status(result) mustEqual OK
+          contentAsString(result) mustEqual view(draftId, None)(
+            messages(application),
+            request
+          ).toString
+        }
+      }
+
+      "must remove file and redirect back when file status is Success" in {
+        fail  //TODO.
       }
     }
 

--- a/test/controllers/UploadSupportingDocumentsControllerSpec.scala
+++ b/test/controllers/UploadSupportingDocumentsControllerSpec.scala
@@ -310,5 +310,33 @@ class UploadSupportingDocumentsControllerSpec
         eqTo(fileUrl)
       )(any())
     }
+
+    "must redirect to fallback page" in {
+      val application = applicationBuilder(userAnswers = Some(userAnswers))
+        .overrides(
+          bind[FileService].toInstance(mockFileService)
+        )
+        .build()
+
+      val view = application.injector.instanceOf[UploadSupportingDocumentsView]
+
+      when(mockFileService.initiate(eqTo(draftId), eqTo(redirectPath), eqTo(false))(any()))
+        .thenReturn(Future.successful(upscanInitiateResponse))
+
+      val request = FakeRequest(
+        GET,
+        controllers.routes.UploadSupportingDocumentsController
+          .onPageLoad(NormalMode, draftId, None, None)
+          .url
+      )
+
+      val result = route(application, request).value
+      status(result) mustEqual OK
+      contentAsString(result) mustEqual view(
+        draftId = draftId,
+        upscanInitiateResponse = Some(upscanInitiateResponse),
+        errorMessage = None
+      )(messages(application), request).toString
+    }
   }
 }

--- a/test/controllers/UploadSupportingDocumentsControllerSpec.scala
+++ b/test/controllers/UploadSupportingDocumentsControllerSpec.scala
@@ -71,9 +71,10 @@ class UploadSupportingDocumentsControllerSpec
   private val initiatedFile =
     UploadedFile.Initiated("reference")
 
+  private val fileUrl        = "some/path/for/the/download/url"
   private val successfulFile = UploadedFile.Success(
     reference = "reference",
-    downloadUrl = "downloadUrl",
+    downloadUrl = fileUrl,
     uploadDetails = UploadedFile.UploadDetails(
       fileName = "fileName",
       fileMimeType = "fileMimeType",
@@ -290,15 +291,13 @@ class UploadSupportingDocumentsControllerSpec
         )
         .build()
 
-      when(mockFileService.initiate(any(), any(), any())(any()))
-        .thenReturn(Future.successful(upscanInitiateResponse))
-      when(mockFileUploadHelper.removeFile(any(), any(), any())(any()))
+      when(mockFileUploadHelper.removeFile(eqTo(NormalMode), eqTo(draftId), eqTo(fileUrl))(any()))
         .thenReturn(Future.successful(play.api.mvc.Results.Ok("")))
 
       val request = FakeRequest(
         GET,
         controllers.routes.UploadSupportingDocumentsController
-          .onPageLoad(models.NormalMode, draftId, None, None)
+          .onPageLoad(NormalMode, draftId, None, None)
           .url
       )
 
@@ -308,7 +307,7 @@ class UploadSupportingDocumentsControllerSpec
       verify(mockFileUploadHelper).removeFile(
         eqTo(NormalMode),
         eqTo(draftId),
-        any()
+        eqTo(fileUrl)
       )(any())
     }
   }

--- a/test/controllers/UploadSupportingDocumentsControllerSpec.scala
+++ b/test/controllers/UploadSupportingDocumentsControllerSpec.scala
@@ -267,6 +267,8 @@ class UploadSupportingDocumentsControllerSpec
 
       when(mockFileService.initiate(any(), any(), any())(any()))
         .thenReturn(Future.successful(upscanInitiateResponse))
+      when(mockFileUploadHelper.removeFile(any(),any(),any())(any()))
+        .thenReturn(Future.successful(play.api.mvc.Results.Ok("test")))
 
       val request = FakeRequest(
         GET,
@@ -277,18 +279,18 @@ class UploadSupportingDocumentsControllerSpec
 
       val result = route(application, request).value
 
-      status(result) mustEqual OK
-      contentAsString(result) mustEqual view(
-        draftId = draftId,
-        upscanInitiateResponse = Some(upscanInitiateResponse),
-        errorMessage = None
-      )(messages(application), request).toString
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(
+          draftId = draftId,
+          upscanInitiateResponse = Some(upscanInitiateResponse),
+          errorMessage = None
+        )(messages(application), request).toString
 
-      verify(mockFileUploadHelper).removeFile(
-        eqTo(NormalMode),
-        eqTo(draftId),
-        any()
-      )(any())
+        verify(mockFileUploadHelper).removeFile(
+          eqTo(NormalMode),
+          eqTo(draftId),
+          any()
+        )(any())
     }
   }
 


### PR DESCRIPTION
### Type of change
- [x] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Browser back from Upload In Progress page causes error](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-394)

The fix is to check if the a file has the "Success" status in the UploadInProgressController and UploadSupportingDocumentsController controllers and in this case remove the file and redirect to the fallback page (UploadSupportingDocumentPage).

Note that under normal operation, the UploadSupportingDocumentsController.onPageLoad and UploadInProgressController.onPageLoad methods will not have the "Success" status.