### PR TITLE
ARSSTB-431 Turning agent creds on permanently

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -82,17 +82,9 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
     configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
   val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/advance-valuation-ruling"
 
-  val agentOnBehalfOfTrader: Boolean = {
-    val path = "features.agent-on-behalf-of-trader"
-    configuration
-      .getOptional[Boolean](path)
-      .getOrElse {
-        // This feature will be disabled by default until the whole user journey is implemented.
-        // If there is no flag in the config file the application will silently ignore it
-        logger.debug(s"$path is disabled")
-        false
-      }
-  }
+  // ARSSTB-431 - We are turning agent creds feature on permanently for the go live
+  // This flag will later be removed completely in ARSSTB-433 with all the other code that use it
+  val agentOnBehalfOfTrader: Boolean = true
 
   def languageMap: Map[String, Lang] = Map(
     "en" -> Lang("en"),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -179,10 +179,6 @@ tracking-consent-frontend {
   gtm.container = "transitional"
 }
 
-features {
-  agent-on-behalf-of-trader: false
-}
-
 upscan {
   callbackBaseUrl = "http://localhost:12600"
   minFileSize = 0

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -16,29 +16,30 @@
 
 package controllers
 
-import base.SpecBase
-import config.FrontendAppConfig
-import connectors.BackendConnector
-import models.AuthUserType.IndividualTrader
-import models._
-import models.requests._
-import org.mockito.ArgumentMatchers.any
-import org.mockito.{Mockito, MockitoSugar}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterEach, TryValues}
-import pages._
+import scala.concurrent.Future
+
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
+
+import base.SpecBase
+import config.FrontendAppConfig
+import connectors.BackendConnector
+import models._
+import models.AuthUserType.IndividualTrader
+import models.requests._
+import org.mockito.{Mockito, MockitoSugar}
+import org.mockito.ArgumentMatchers.any
+import org.scalatest.{BeforeAndAfterEach, TryValues}
+import org.scalatest.concurrent.ScalaFutures
+import pages._
 import services.SubmissionService
 import userrole.{UserRole, UserRoleProvider}
 import viewmodels.checkAnswers.summary.{ApplicationSummary, _}
 import viewmodels.govuk.SummaryListFluency
-
-import scala.concurrent.Future
 
 class CheckYourAnswersControllerSpec
     extends SpecBase

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -16,32 +16,29 @@
 
 package controllers
 
-import scala.concurrent.Future
-
+import base.SpecBase
+import config.FrontendAppConfig
+import connectors.BackendConnector
+import models.AuthUserType.IndividualTrader
+import models._
+import models.requests._
+import org.mockito.ArgumentMatchers.any
+import org.mockito.{Mockito, MockitoSugar}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterEach, TryValues}
+import pages._
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-
-import base.SpecBase
-import config.FrontendAppConfig
-import connectors.BackendConnector
-import models._
-import models.AuthUserType.IndividualTrader
-import models.requests._
-import org.mockito.{Mockito, MockitoSugar}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatest.{BeforeAndAfterEach, TryValues}
-import org.scalatest.concurrent.ScalaFutures
-import pages._
 import services.SubmissionService
 import userrole.{UserRole, UserRoleProvider}
-import viewmodels.checkAnswers.summary.{ApplicationSummary, ApplicationSummaryService, DetailsSummary, IndividualApplicantSummary, IndividualEoriDetailsSummary, MethodSummary}
+import viewmodels.checkAnswers.summary.{ApplicationSummary, _}
 import viewmodels.govuk.SummaryListFluency
-import views.html.CheckYourAnswersView
+
+import scala.concurrent.Future
 
 class CheckYourAnswersControllerSpec
     extends SpecBase
@@ -105,44 +102,6 @@ class CheckYourAnswersControllerSpec
 
           status(result) mustEqual OK
           contentAsString(result) mustEqual expectedText
-        }
-      }
-
-    "must return OK and the correct view for a GET with affinityGroup Individual" in
-      new CheckYourAnswersControllerSpecSetup {
-
-        val application = applicationBuilder(userAnswers = Option(userAnswers))
-          .overrides(
-            bind[BackendConnector].toInstance(mockBackendConnector),
-            bind[ApplicationSummaryService].toInstance(mockApplicationSummaryService)
-          )
-          .build()
-
-        implicit val msgs = messages(application)
-
-        when(
-          mockBackendConnector.getTraderDetails(any(), any())(any(), any())
-        ) thenReturn Future
-          .successful(
-            Right(
-              traderDetailsWithCountryCode
-            )
-          )
-
-        running(application) {
-          implicit val request =
-            FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad(draftId).url)
-
-          val result = route(application, request).value
-
-          val view = application.injector.instanceOf[CheckYourAnswersView]
-          val list = mockApplicationSummaryService.getApplicationSummary(
-            userAnswers,
-            traderDetailsWithCountryCode
-          )
-
-          status(result) mustEqual OK
-          contentAsString(result) mustEqual view(list, draftId).toString
         }
       }
 

--- a/test/controllers/CheckYourAnswersForAgentsControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersForAgentsControllerSpec.scala
@@ -213,7 +213,9 @@ class CheckYourAnswersForAgentsControllerSpec
           .futureValue
 
         val appSummary = ApplicationSummary(
-          IndividualEoriDetailsSummary(traderDetailsWithCountryCode, draftId)(stubMessages()),
+          IndividualEoriDetailsSummary(traderDetailsWithCountryCode, draftId, userAnswers)(
+            stubMessages()
+          ),
           IndividualApplicantSummary(userAnswers)(stubMessages()),
           DetailsSummary(userAnswers)(stubMessages()),
           MethodSummary(userAnswers)(stubMessages())

--- a/test/controllers/CheckYourAnswersForAgentsControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersForAgentsControllerSpec.scala
@@ -16,28 +16,29 @@
 
 package controllers
 
-import base.SpecBase
-import connectors.BackendConnector
-import models.AuthUserType._
-import models.WhatIsYourRoleAsImporter.{AgentOnBehalfOfOrg, EmployeeOfOrg}
-import models._
-import models.requests.{ApplicationId, ApplicationSubmissionResponse}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.MockitoSugar
-import org.scalatest.{EitherValues, TryValues}
-import pages._
+import scala.concurrent.Future
+
 import play.api.Application
 import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.{AnyContentAsEmpty, Request}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+
+import base.SpecBase
+import connectors.BackendConnector
+import models._
+import models.AuthUserType._
+import models.WhatIsYourRoleAsImporter.{AgentOnBehalfOfOrg, EmployeeOfOrg}
+import models.requests.{ApplicationId, ApplicationSubmissionResponse}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar
+import org.scalatest.{EitherValues, TryValues}
+import pages._
 import services.SubmissionService
 import viewmodels.checkAnswers.summary._
 import viewmodels.govuk.SummaryListFluency
 import views.html.CheckYourAnswersForAgentsView
-
-import scala.concurrent.Future
 
 class CheckYourAnswersForAgentsControllerSpec
     extends SpecBase

--- a/test/controllers/UploadSupportingDocumentsControllerSpec.scala
+++ b/test/controllers/UploadSupportingDocumentsControllerSpec.scala
@@ -28,6 +28,7 @@ import base.SpecBase
 import config.FrontendAppConfig
 import controllers.common.FileUploadHelper
 import models.{DraftAttachment, NormalMode, UploadedFile}
+import models.WhatIsYourRoleAsImporter.EmployeeOfOrg
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.Mockito.when
@@ -69,6 +70,9 @@ class UploadSupportingDocumentsControllerSpec
   "When the page is loaded it must display the expected content" in {
     val userAnswers = userAnswersAsIndividualTrader
       .set(UploadSupportingDocumentPage, successfulFile)
+      .success
+      .value
+      .set(WhatIsYourRoleAsImporterPage, EmployeeOfOrg)
       .success
       .value
 


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Set Agent Creds feature flag default to true](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-431)

This simple change turns the agent creds feature on permanently, regardless of the application configuration.

Note: removing the parts that check for the flag is not in scope for this ticket (that will come after we successfully released the application into production.

Note #2: The UI tests must be adjusted after this PR is merged, because there's no way to turn agent creds off any more.