### PR TITLE
Save EORI and radio button status on 2 pages

### DIFF
--- a/app/controllers/VerifyTraderEoriController.scala
+++ b/app/controllers/VerifyTraderEoriController.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import controllers.actions._
 import forms.VerifyTraderDetailsFormProvider
-import models.{DraftId, Mode, TraderDetailsWithConfirmation}
+import models.{DraftId, Mode}
 import pages.{CheckRegisteredDetailsPage, VerifyTraderDetailsPage}
 import services.UserAnswersService
 import views.html.{VerifyPrivateTraderDetailView, VerifyPublicTraderDetailView}
@@ -48,16 +48,11 @@ class VerifyTraderEoriController @Inject() (
     with I18nSupport
     with Logging {
 
-  private def getForm(details: TraderDetailsWithConfirmation) =
-    details.confirmation match {
-      case Some(value) => formProvider().fill(value.toString)
-      case None        => formProvider()
+  private def checkForm(isChecked: Option[Boolean]) =
+    isChecked match {
+      case Some(isChecked) => formProvider().fill(isChecked.toString)
+      case None            => formProvider()
     }
-
-  private def checkForm(isChecked: Option[Boolean]) = isChecked match {
-    case Some(isChecked) => formProvider().fill(isChecked.toString)
-    case None            => formProvider()
-  }
 
   def onPageLoad(mode: Mode, draftId: DraftId): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {

--- a/app/controllers/VerifyTraderEoriController.scala
+++ b/app/controllers/VerifyTraderEoriController.scala
@@ -54,16 +54,23 @@ class VerifyTraderEoriController @Inject() (
       case None        => formProvider()
     }
 
+  private def checkForm(isChecked: Option[Boolean]) = isChecked match {
+    case Some(isChecked) => formProvider().fill(isChecked.toString)
+    case None            => formProvider()
+  }
+
   def onPageLoad(mode: Mode, draftId: DraftId): Action[AnyContent] =
     (identify andThen getData(draftId) andThen requireData) {
       implicit request =>
+        val checked = CheckRegisteredDetailsPage.get()
+
         VerifyTraderDetailsPage.get() match {
           case None                                                       =>
             traderDetailsNotFoundInSession(draftId)
           case Some(details) if details.consentToDisclosureOfPersonalData =>
-            Ok(publicView(getForm(details), mode, draftId, details))
+            Ok(publicView(checkForm(checked), mode, draftId, details))
           case Some(details)                                              =>
-            Ok(privateView(getForm(details), mode, draftId, details))
+            Ok(privateView(checkForm(checked), mode, draftId, details))
         }
     }
 

--- a/app/views/ProvideTraderEoriView.scala.html
+++ b/app/views/ProvideTraderEoriView.scala.html
@@ -30,10 +30,11 @@
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
-
+@onSubmitAction(saveDraft: Boolean = true) = @{routes.ProvideTraderEoriController.onSubmit(draftId, saveDraft)
+}
 @layout(pageTitle = title(form, messages("provideTraderEori.heading")), draftId = Some(draftId)) {
 
-    @formHelper(action = controllers.routes.ProvideTraderEoriController.onSubmit(draftId = draftId, saveDraft = false)) {
+    @formHelper(action = onSubmitAction(saveDraft = false)) {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
@@ -45,14 +46,18 @@
 
         @paragraph(Html(messages("provideTraderEori.p1")))
 
-        <label class="govuk-label govuk-visually-hidden" for="value">
-            @messages("provideTraderEori.heading")
-        </label>
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = Label(
+                    content = Text(messages("provideTraderEori.heading")),
+                    classes = "govuk-visually-hidden"
+                )
+            )
+            .withWidth(Full)
+        )
 
-        <input class="govuk-input  govuk-!-width-full" id="value" name="value" type="text">
-        <br><br/>
-
-        @saveButtons(draftId, controllers.routes.ProvideTraderEoriController.onSubmit(draftId = draftId, saveDraft = true))
+        @saveButtons(draftId, onSubmitAction())
     }
 
     @cancelApplicationLink(draftId)

--- a/test/controllers/VerifyTraderEoriControllerSpec.scala
+++ b/test/controllers/VerifyTraderEoriControllerSpec.scala
@@ -29,7 +29,7 @@ import models.{Done, NormalMode, TraderDetailsWithConfirmation}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
-import pages.VerifyTraderDetailsPage
+import pages.{CheckRegisteredDetailsPage, VerifyTraderDetailsPage}
 import services.UserAnswersService
 import views.html.{VerifyPrivateTraderDetailView, VerifyPublicTraderDetailView}
 
@@ -116,6 +116,11 @@ class VerifyTraderEoriControllerSpec extends SpecBase with MockitoSugar {
         .setFuture[TraderDetailsWithConfirmation](
           VerifyTraderDetailsPage,
           traderDetailsWithConfirmation.copy(confirmation = Some(true))
+        )
+        .futureValue
+        .setFuture[Boolean](
+          CheckRegisteredDetailsPage,
+          true
         )
         .futureValue
 


### PR DESCRIPTION
### Type of change
- [x] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [EORI number and option selected on EORI details pages not saved](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-450)

The EORI on the /provide-trader-eori page and the radio button selection on the /check-trader-EORI-details pages is now saved when the user navigates back through the journey e.g. after saving as draft. Note that the EORI (text field input) is saved when the Save as draft button is selected on the same page whereas the radio button selection is saved when the Save as draft button is selected on a subsequent page. This behaviour is consistent with the rest of the journey.
