### PR TITLE
added CSRF tokens to supported documents and letter of authority page

### DIFF
--- a/app/views/UploadLetterOfAuthorityView.scala.html
+++ b/app/views/UploadLetterOfAuthorityView.scala.html
@@ -17,9 +17,9 @@
 @import config.FrontendAppConfig
 @import models.upscan.UpscanInitiateResponse
 @import components._
+@import helper._
 
 @this(  mainLayout: templates.Layout,
-        formHelper: FormWithCSRF,
         govukButton: GovukButton,
         govukErrorSummary: GovukErrorSummary,
         caption: Caption,
@@ -67,6 +67,7 @@
       @for(field <- upscanInitiateResponse.uploadRequest.fields) {
         <input type="hidden" name="@field._1" value="@field._2"/>
       }
+        @CSRF.formField
 
       @content
 

--- a/app/views/UploadSupportingDocumentsView.scala.html
+++ b/app/views/UploadSupportingDocumentsView.scala.html
@@ -17,9 +17,9 @@
 @import config.FrontendAppConfig
 @import models.upscan.UpscanInitiateResponse
 @import components._
+@import helper._
 
 @this(  mainLayout: templates.Layout,
-        formHelper: FormWithCSRF,
         govukButton: GovukButton,
         govukErrorSummary: GovukErrorSummary,
         caption: Caption,
@@ -64,6 +64,7 @@
       @for(field <- upscanInitiateResponse.uploadRequest.fields) {
         <input type="hidden" name="@field._1" value="@field._2"/>
       }
+        @CSRF.formField
 
       @content
 

--- a/test/controllers/FileUploadHelperSpec.scala
+++ b/test/controllers/FileUploadHelperSpec.scala
@@ -26,7 +26,8 @@ import play.api.http.HttpEntity
 import play.api.i18n.{Messages, MessagesApi, MessagesProvider}
 import play.api.inject.bind
 import play.api.mvc.{AnyContent, Cookie, ResponseHeader, Result}
-import play.api.test.FakeRequest
+import play.api.test.{CSRFTokenHelper, FakeRequest}
+import play.api.test.CSRFTokenHelper._
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.http.HeaderCarrier
@@ -603,7 +604,7 @@ class FileUploadHelperSpec extends SpecBase with MockitoSugar with BeforeAndAfte
       application: Application
     ) = {
       val request =
-        FakeRequest(GET, getRedirectPath(errorCode = Some(errCode)))
+        CSRFTokenHelper.addCSRFToken(FakeRequest(GET, getRedirectPath(errorCode = Some(errCode))))
       val result  = route(application, request).value
 
       status(result) mustEqual BAD_REQUEST

--- a/test/controllers/UploadInProgressControllerSpec.scala
+++ b/test/controllers/UploadInProgressControllerSpec.scala
@@ -22,8 +22,8 @@ import scala.concurrent.Future
 
 import play.api.Application
 import play.api.inject.bind
-import play.api.mvc.AnyContentAsEmpty
-import play.api.test.FakeRequest
+import play.api.mvc.{AnyContentAsEmpty, Request}
+import play.api.test.{CSRFTokenHelper, FakeRequest}
 import play.api.test.Helpers._
 
 import base.SpecBase
@@ -146,7 +146,7 @@ class UploadInProgressControllerSpec
   private def expectedContentForView(
     isLetterOfAuthority: Boolean,
     application: Application,
-    request: FakeRequest[AnyContentAsEmpty.type]
+    request: Request[AnyContentAsEmpty.type]
   ) =
     if (isLetterOfAuthority) {
       val view = application.injector.instanceOf[UploadLetterOfAuthorityView]
@@ -202,11 +202,13 @@ class UploadInProgressControllerSpec
         )
           .thenReturn(Future.successful(upscanInitiateResponse))
 
-        val request = FakeRequest(
-          POST,
-          controllers.routes.UploadInProgressController
-            .checkProgress(draftId, Some("otherReference"), isLetterOfAuthority)
-            .url
+        val request = CSRFTokenHelper.addCSRFToken(
+          FakeRequest(
+            POST,
+            controllers.routes.UploadInProgressController
+              .checkProgress(draftId, Some("otherReference"), isLetterOfAuthority)
+              .url
+          )
         )
 
         val expectedContent = expectedContentForView(isLetterOfAuthority, application, request)
@@ -328,11 +330,13 @@ class UploadInProgressControllerSpec
                 .thenReturn(Future.successful(upscanInitiateResponse))
 
               running(application) {
-                val request = FakeRequest(
-                  GET,
-                  routes.UploadInProgressController
-                    .onPageLoad(draftId, None, isLetterOfAuthority)
-                    .url
+                val request = CSRFTokenHelper.addCSRFToken(
+                  FakeRequest(
+                    GET,
+                    routes.UploadInProgressController
+                      .onPageLoad(draftId, None, isLetterOfAuthority)
+                      .url
+                  )
                 )
 
                 val expectedContent =


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [X] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Use FormWithCSRF in UploadSupportingDocumentsView](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-417)

Added CSRF token using helpers to both UploadSupportingDocumentsView and UploadLetterOfAuthorityView.