### PR TITLE
ARSSTB-500 Legends added to Fieldsets

### DIFF
--- a/app/views/AreThereRestrictionsOnTheGoodsView.scala.html
+++ b/app/views/AreThereRestrictionsOnTheGoodsView.scala.html
@@ -27,16 +27,11 @@
     heading: Heading,
     paragraph: Paragraph,
     subheading: Subheading,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    legend: LegendH2
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
-
-@legend = {
-    <h2 class='govuk-fieldset__legend--m'>
-        @messages("areThereRestrictionsOnTheGoods.question")
-    </h2>
-}
 
 @layout(pageTitle = title(form, messages("areThereRestrictionsOnTheGoods.title")), draftId = Some(draftId)) {
 
@@ -61,7 +56,7 @@
                 field = form("value"),
                 legend = Legend(
                     HtmlContent(
-                        legend.toString
+                        legend(messages("areThereRestrictionsOnTheGoods.question")).toString
                     )
                 ),
             )

--- a/app/views/AreThereRestrictionsOnTheGoodsView.scala.html
+++ b/app/views/AreThereRestrictionsOnTheGoodsView.scala.html
@@ -32,6 +32,12 @@
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
 
+@legend = {
+    <h2 class='govuk-fieldset__legend--m'>
+        @messages("areThereRestrictionsOnTheGoods.question")
+    </h2>
+}
+
 @layout(pageTitle = title(form, messages("areThereRestrictionsOnTheGoods.title")), draftId = Some(draftId)) {
 
     @formHelper(action = routes.AreThereRestrictionsOnTheGoodsController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
@@ -50,12 +56,14 @@
             Html(messages("areThereRestrictionsOnTheGoods.bulletPoint.3"))
         ))
 
-        @subheading(messages("areThereRestrictionsOnTheGoods.question"))
-
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = Legend(),
+                legend = Legend(
+                    HtmlContent(
+                        legend.toString
+                    )
+                ),
             )
         )
 

--- a/app/views/DoYouWantToUploadDocumentsView.scala.html
+++ b/app/views/DoYouWantToUploadDocumentsView.scala.html
@@ -56,7 +56,7 @@
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = legend = Legend(
+                legend = Legend(
                     HtmlContent(
                         legend(messages("doYouWantToUploadDocuments.question")).toString
                     )

--- a/app/views/DoYouWantToUploadDocumentsView.scala.html
+++ b/app/views/DoYouWantToUploadDocumentsView.scala.html
@@ -27,7 +27,8 @@
     heading: Heading,
     cancelLink: CancelApplicationLink,
     subheading: Subheading,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    legend: LegendH2
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
@@ -52,12 +53,14 @@
         "govuk-list govuk-list--bullet",
         )
 
-        @subheading(messages("doYouWantToUploadDocuments.question"))
-
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = Legend()
+                legend = legend = Legend(
+                    HtmlContent(
+                        legend(messages("doYouWantToUploadDocuments.question")).toString
+                    )
+                ),
             )
         )
 

--- a/app/views/HasCommodityCodeView.scala.html
+++ b/app/views/HasCommodityCodeView.scala.html
@@ -62,7 +62,7 @@
 
         @caption(messages("hasCommodityCode.caption"))
 
-        @radios(messages("hasCommodityCode.heading"), radiosContent, form("value"))
+        @radios(messages("hasCommodityCode.heading"), radiosContent, form)
 
         @saveButtons(draftId)
     }

--- a/app/views/HasCommodityCodeView.scala.html
+++ b/app/views/HasCommodityCodeView.scala.html
@@ -29,7 +29,8 @@
     config: FrontendAppConfig,
     detailsDrop: DetailsDrop,
     cancelApplicationLink: CancelApplicationLink,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    radios: YesNoRadios
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
@@ -47,6 +48,10 @@
                     searchLink)
                 )}
 
+@radiosContent = {
+    <p class="govuk-body">@detailsContent</p>
+}
+
 @layout(pageTitle = title(form, messages("hasCommodityCode.title")), draftId = Some(draftId)) {
 
     @formHelper(action = routes.HasCommodityCodeController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
@@ -57,16 +62,7 @@
 
         @caption(messages("hasCommodityCode.caption"))
 
-        @heading(s"${messages("hasCommodityCode.heading")}")
-
-        <p class="govuk-body">@detailsContent</p>
-
-        @govukRadios(
-            RadiosViewModel.yesNo(
-                field = form("value"),
-                legend = Legend()
-            )
-        )
+        @radios(messages("hasCommodityCode.heading"), radiosContent, form("value"))
 
         @saveButtons(draftId)
     }

--- a/app/views/HasConfidentialInformationView.scala.html
+++ b/app/views/HasConfidentialInformationView.scala.html
@@ -26,10 +26,17 @@
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
     insetPara: InsetPara,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    radios: YesNoRadios
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
+
+@radiosContent = {
+    @paragraph(Html(messages("hasConfidentialInformation.paragraph.1")))
+    @paragraph(Html(messages("hasConfidentialInformation.paragraph.2")))
+    @insetPara(Html(messages("hasConfidentialInformation.paragraph.inset")))
+}
 
 @layout(pageTitle = title(form, messages("hasConfidentialInformation.title")), draftId = Some(draftId)) {
 
@@ -40,18 +47,8 @@
         }
 
         @caption(messages("hasConfidentialInformation.caption"))
-        @heading(messages("hasConfidentialInformation.heading"))
 
-        @paragraph(Html(messages("hasConfidentialInformation.paragraph.1")))
-        @paragraph(Html(messages("hasConfidentialInformation.paragraph.2")))
-        @insetPara(Html(messages("hasConfidentialInformation.paragraph.inset")))
-
-        @govukRadios(
-            RadiosViewModel.yesNo(
-                field = form("value"),
-                legend = Legend()
-            )
-        )
+        @radios(messages("hasConfidentialInformation.heading"), radiosContent, form("value"))
 
         @saveButtons(draftId)
     }

--- a/app/views/HasConfidentialInformationView.scala.html
+++ b/app/views/HasConfidentialInformationView.scala.html
@@ -48,7 +48,7 @@
 
         @caption(messages("hasConfidentialInformation.caption"))
 
-        @radios(messages("hasConfidentialInformation.heading"), radiosContent, form("value"))
+        @radios(messages("hasConfidentialInformation.heading"), radiosContent, form)
 
         @saveButtons(draftId)
     }

--- a/app/views/HaveTheGoodsBeenSubjectToLegalChallengesView.scala.html
+++ b/app/views/HaveTheGoodsBeenSubjectToLegalChallengesView.scala.html
@@ -25,10 +25,16 @@
     heading: Heading,
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    radios: YesNoRadios
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
+
+@radiosContent = {
+    @paragraph(Html(messages("haveTheGoodsBeenSubjectToLegalChallenges.para.1")))
+    @paragraph(Html(messages("haveTheGoodsBeenSubjectToLegalChallenges.para.2")))
+}
 
 @layout(pageTitle = title(form, messages("haveTheGoodsBeenSubjectToLegalChallenges.title")), draftId = Some(draftId)) {
 
@@ -39,16 +45,8 @@
         }
 
         @caption(messages("haveTheGoodsBeenSubjectToLegalChallenges.caption"))
-        @heading(messages("haveTheGoodsBeenSubjectToLegalChallenges.heading"))
-        @paragraph(Html(messages("haveTheGoodsBeenSubjectToLegalChallenges.para.1")))
-        @paragraph(Html(messages("haveTheGoodsBeenSubjectToLegalChallenges.para.2")))
 
-        @govukRadios(
-            RadiosViewModel.yesNo(
-                field = form("value"),
-                legend = Legend()
-            )
-        )
+        @radios(messages("haveTheGoodsBeenSubjectToLegalChallenges.heading"), radiosContent, form("value"))
 
         @saveButtons(draftId)
     }

--- a/app/views/HaveTheGoodsBeenSubjectToLegalChallengesView.scala.html
+++ b/app/views/HaveTheGoodsBeenSubjectToLegalChallengesView.scala.html
@@ -46,7 +46,7 @@
 
         @caption(messages("haveTheGoodsBeenSubjectToLegalChallenges.caption"))
 
-        @radios(messages("haveTheGoodsBeenSubjectToLegalChallenges.heading"), radiosContent, form("value"))
+        @radios(messages("haveTheGoodsBeenSubjectToLegalChallenges.heading"), radiosContent, form)
 
         @saveButtons(draftId)
     }

--- a/app/views/HaveYouUsedMethodOneForSimilarGoodsInPastView.scala.html
+++ b/app/views/HaveYouUsedMethodOneForSimilarGoodsInPastView.scala.html
@@ -61,7 +61,7 @@
 
         @caption(messages("haveYouUsedMethodOneForSimilarGoodsInPast.caption"))
 
-        @radios(messages("haveYouUsedMethodOneForSimilarGoodsInPast.heading"), radiosContent, form("value"))
+        @radios(messages("haveYouUsedMethodOneForSimilarGoodsInPast.heading"), radiosContent, form)
 
         @saveButtons(draftId)
     }

--- a/app/views/HaveYouUsedMethodOneForSimilarGoodsInPastView.scala.html
+++ b/app/views/HaveYouUsedMethodOneForSimilarGoodsInPastView.scala.html
@@ -28,11 +28,28 @@
     bulletList: BulletList,
     insetPara: InsetPara,
     subheading: Subheading,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    radios: YesNoRadios
 )
 
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
+
+@radiosContent = {
+    @paragraph(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.1")))
+    @paragraph(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.2")))
+    @bulletList(Seq(
+    Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.1")),
+    Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.2")),
+    ))
+    @insetPara(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.inset")))
+    @paragraph(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.3")))
+    @bulletList(Seq(
+    Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.3")),
+    Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.4")),
+    Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.5")),
+    ))
+}
 
 @layout(pageTitle = title(form, messages("haveYouUsedMethodOneForSimilarGoodsInPast.title")), draftId = Some(draftId)) {
 
@@ -43,27 +60,8 @@
         }
 
         @caption(messages("haveYouUsedMethodOneForSimilarGoodsInPast.caption"))
-        @heading(messages("haveYouUsedMethodOneForSimilarGoodsInPast.heading"))
-        @paragraph(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.1")))
-        @paragraph(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.2")))
-        @bulletList(Seq(
-            Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.1")),
-            Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.2")),
-        ))
-        @insetPara(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.inset")))
-        @paragraph(Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.paragraph.3")))
-        @bulletList(Seq(
-            Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.3")),
-            Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.4")),
-            Html(messages("haveYouUsedMethodOneForSimilarGoodsInPast.bulletPoint.5")),
-        ))
 
-        @govukRadios(
-            RadiosViewModel.yesNo(
-                field = form("value"),
-                legend = Legend()
-            )
-        )
+        @radios(messages("haveYouUsedMethodOneForSimilarGoodsInPast.heading"), radiosContent, form("value"))
 
         @saveButtons(draftId)
     }

--- a/app/views/HaveYouUsedMethodOneInPastView.scala.html
+++ b/app/views/HaveYouUsedMethodOneInPastView.scala.html
@@ -28,7 +28,8 @@
     bulletList: BulletList,
     insetPara: InsetPara,
     subheading: Subheading,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    legend: LegendH2
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
@@ -51,12 +52,15 @@
         Html(messages("haveYouUsedMethodOneInPast.bulletPoint.2")),
         Html(messages("haveYouUsedMethodOneInPast.bulletPoint.3")),
     ))
-    @subheading(messages("haveYouUsedMethodOneInPast.question"))
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = Legend()
+                legend = Legend(
+                    HtmlContent(
+                        legend(messages("haveYouUsedMethodOneInPast.question")).toString
+                    )
+                )
             )
         )
 

--- a/app/views/IsSaleBetweenRelatedPartiesView.scala.html
+++ b/app/views/IsSaleBetweenRelatedPartiesView.scala.html
@@ -25,10 +25,15 @@
     heading: Heading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    radios: YesNoRadios
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
+
+@radiosContent = {
+    @paragraph(content = Html(messages("isSaleBetweenRelatedParties.para")))
+}
 
 @layout(pageTitle = title(form, messages("isSaleBetweenRelatedParties.title")), draftId = Some(draftId)) {
 
@@ -39,15 +44,8 @@
         }
 
         @caption(messages("isSaleBetweenRelatedParties.caption"))
-        @heading(messages("isSaleBetweenRelatedParties.heading"))
-        @paragraph(content = Html(messages("isSaleBetweenRelatedParties.para")))
 
-        @govukRadios(
-            RadiosViewModel.yesNo(
-                field = form("value"),
-                legend = Legend()
-            )
-        )
+        @radios(messages("isSaleBetweenRelatedParties.heading"), radiosContent, form("value"))
 
         @saveButtons(draftId)
     }

--- a/app/views/IsSaleBetweenRelatedPartiesView.scala.html
+++ b/app/views/IsSaleBetweenRelatedPartiesView.scala.html
@@ -45,7 +45,7 @@
 
         @caption(messages("isSaleBetweenRelatedParties.caption"))
 
-        @radios(messages("isSaleBetweenRelatedParties.heading"), radiosContent, form("value"))
+        @radios(messages("isSaleBetweenRelatedParties.heading"), radiosContent, form)
 
         @saveButtons(draftId)
     }

--- a/app/views/IsTheSaleSubjectToConditionsView.scala.html
+++ b/app/views/IsTheSaleSubjectToConditionsView.scala.html
@@ -27,7 +27,8 @@
     heading: Heading,
     paragraph: Paragraph,
     subheading: Subheading,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    legend: LegendH2
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
@@ -50,12 +51,14 @@
             Html(messages("isTheSaleSubjectToConditions.bulletPoint.3"))
         ))
 
-        @subheading(messages("isTheSaleSubjectToConditions.question"))
-
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = Legend(),
+                legend = Legend(
+                    HtmlContent(
+                        legend(messages("isTheSaleSubjectToConditions.question")).toString
+                    )
+                )
             )
         )
 

--- a/app/views/IsThisFileConfidentialView.scala.html
+++ b/app/views/IsThisFileConfidentialView.scala.html
@@ -28,7 +28,8 @@
     paragraph: Paragraph,
     govukButton: GovukButton,
     subheading: Subheading,
-    govukTable: GovukTable
+    govukTable: GovukTable,
+    legend: LegendH2
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId, fileName: String)(implicit request: Request[_], messages: Messages)
@@ -55,14 +56,16 @@
     @paragraph(Html(messages("isThisFileConfidential.para.1")))
     @paragraph(Html(messages("isThisFileConfidential.para.2")))
 
-    @subheading(messages("isThisFileConfidential.question"))
-
     @formHelper(action = routes.IsThisFileConfidentialController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
         
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = Legend()
+                legend = Legend(
+                    HtmlContent(
+                        legend(messages("isThisFileConfidential.question")).toString
+                    )
+                )
             )
         )
 

--- a/app/views/UploadAnotherSupportingDocumentView.scala.html
+++ b/app/views/UploadAnotherSupportingDocumentView.scala.html
@@ -29,7 +29,8 @@
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
     link: Link,
-    saveButtons: SaveButtons
+    saveButtons: SaveButtons,
+    legend: LegendH2
 )
 
 @(attachments: Seq[DraftAttachment], form: Form[_], mode: Mode, draftId: DraftId, letterOfAuthorityFileName: Option[String] = None)(implicit request: Request[_], messages: Messages)
@@ -148,11 +149,14 @@
 
         @if(letterOfAuthorityFileName.isDefined) {
             @if(numOfDocs != 4) {
-                @subheading(messages("uploadAnotherSupportingDocument.subHeading"))
                 @govukRadios(
                     RadiosViewModel.yesNo(
                         field = form("value"),
-                        legend = Legend()
+                        legend = Legend(
+                            HtmlContent(
+                                legend(messages("uploadAnotherSupportingDocument.subHeading")).toString
+                            )
+                        )
                     )
                 )
             } else {
@@ -161,11 +165,14 @@
             }
         } else {
             @if(numOfDocs != 5) {
-                @subheading(messages("uploadAnotherSupportingDocument.subHeading"))
-                    @govukRadios(
-                        RadiosViewModel.yesNo(
+                @govukRadios(
+                    RadiosViewModel.yesNo(
                         field = form("value"),
-                        legend = Legend()
+                        legend = Legend(
+                            HtmlContent(
+                                legend(messages("uploadAnotherSupportingDocument.subHeading")).toString
+                            )
+                        )
                     )
                 )
             } else {

--- a/app/views/WhatIsYourRoleAsImporterView.scala.html
+++ b/app/views/WhatIsYourRoleAsImporterView.scala.html
@@ -27,10 +27,21 @@
     para: Paragraph,
     details: DetailsDrop,
     saveButtons: SaveButtons,
-    config: FrontendAppConfig
+    config: FrontendAppConfig,
+    radios: DescribeRoleRadios
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
+
+@radioContent = {
+    <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-4">
+        @messages("whatIsYourRoleAsImporter.para.1")
+    </p>
+
+    <div class="govuk-inset-text">
+        @messages("whatIsYourRoleAsImporter.warning")
+    </div>
+}
 
 @layout(pageTitle = title(form, messages("whatIsYourRoleAsImporter.title")), draftId = Some(draftId)) {
 
@@ -41,23 +52,8 @@
         }
 
         @caption(messages("caption.applicant"))
-        @heading(messages("whatIsYourRoleAsImporter.heading"))
 
-        <p class="govuk-body govuk-!-margin-top-4 govuk-!-margin-bottom-4">
-            @messages("whatIsYourRoleAsImporter.para.1")
-        </p>
-
-        <div class="govuk-inset-text">
-            @messages("whatIsYourRoleAsImporter.warning")
-        </div>
-
-        @govukRadios(
-            RadiosViewModel(
-                field  = form("value"),
-                legend = Legend(),
-                items  = WhatIsYourRoleAsImporter.options(config)
-            )
-        )
+        @radios(messages("whatIsYourRoleAsImporter.heading"), radioContent, form("value"), messages)
 
         @saveButtons(draftId)
     }

--- a/app/views/WhatIsYourRoleAsImporterView.scala.html
+++ b/app/views/WhatIsYourRoleAsImporterView.scala.html
@@ -53,7 +53,7 @@
 
         @caption(messages("caption.applicant"))
 
-        @radios(messages("whatIsYourRoleAsImporter.heading"), radioContent, form("value"))
+        @radios(messages("whatIsYourRoleAsImporter.heading"), radioContent, form)
 
         @saveButtons(draftId)
     }

--- a/app/views/WhatIsYourRoleAsImporterView.scala.html
+++ b/app/views/WhatIsYourRoleAsImporterView.scala.html
@@ -53,7 +53,7 @@
 
         @caption(messages("caption.applicant"))
 
-        @radios(messages("whatIsYourRoleAsImporter.heading"), radioContent, form("value"), messages)
+        @radios(messages("whatIsYourRoleAsImporter.heading"), radioContent, form("value"))
 
         @saveButtons(draftId)
     }

--- a/app/views/components/DescribeRoleRadios.scala.html
+++ b/app/views/components/DescribeRoleRadios.scala.html
@@ -14,36 +14,23 @@
  * limitations under the License.
  *@
 
-@import play.api.i18n.Messages
-
 @this()
 
-@(heading: String, content: Html, field: Field, messages: Messages)
+@(heading: String, content: Html, form: Form[_])(implicit messages: Messages)
 
 
-@employeeChecked = @{
-if(field.value.isDefined && field.value.get == "employeeOfOrg") {
-"checked"
-} else {
-""
-}
-}
-
-@agentOrgChecked = @{
- if(field.value.isDefined && field.value.get == "agentOnBehalfOfOrg") {
+@(role: String) = @{
+ if (form("value").value.isDefined && form("value").value.get == role) {
   "checked"
  } else {
   ""
  }
 }
 
-@agentTraderChecked = @{
- if(field.value.isDefined && field.value.get == "agentOnBehalfOfTrader") {
-  "checked"
- } else {
-  ""
- }
-}
+@employeeChecked = @role("employeeOfOrg")
+@agentOrgChecked = @role("agentOnBehalfOfOrg")
+@agentTraderChecked = @role("agentOnBehalfOfTrader")
+
 
 <fieldset class="govuk-fieldset govuk-!-margin-bottom-4">
 

--- a/app/views/components/DescribeRoleRadios.scala.html
+++ b/app/views/components/DescribeRoleRadios.scala.html
@@ -62,25 +62,25 @@ if(field.value.isDefined && field.value.get == "employeeOfOrg") {
     <b>@messages("whatIsYourRoleAsImporter.employeeOfOrg")</b>
    </label>
    <div id="value_0-item-hint" class="govuk-hint govuk-radios__hint">
-    Imports goods into the UK on behalf of their organisation.
+    @messages("whatIsYourRoleAsImporter.employeeOfOrg.hint")
    </div>
   </div>
   <div class="govuk-radios__item">
    <input class="govuk-radios__input" id="value_1" name="value" type="radio" value="agentOnBehalfOfOrg" aria-describedby="value_1-item-hint" @agentOrgChecked>
    <label class="govuk-label govuk-radios__label" for="value_1">
-    <b>Agent acting on behalf of an organisation</b>
+    <b>@messages("whatIsYourRoleAsImporter.agentOnBehalfOfOrg")</b>
    </label>
    <div id="value_1-item-hint" class="govuk-hint govuk-radios__hint">
-    Imports goods into the UK on behalf of another organisation.
+    @messages("whatIsYourRoleAsImporter.agentOnBehalfOfOrg.hint")
    </div>
   </div>
   <div class="govuk-radios__item">
    <input class="govuk-radios__input" id="value_2" name="value" type="radio" value="agentOnBehalfOfTrader" aria-describedby="value_2-item-hint" @agentTraderChecked>
    <label class="govuk-label govuk-radios__label" for="value_2">
-    <b>Agent acting on behalf of a trader</b>
+    <b>@messages("whatIsYourRoleAsImporter.agentOnBehalfOfTrader")</b>
    </label>
    <div id="value_2-item-hint" class="govuk-hint govuk-radios__hint">
-    Imports goods into the UK on behalf of an individual trader.
+    @messages("whatIsYourRoleAsImporter.agentOnBehalfOfTrader.hint")
    </div>
   </div>
  </div>

--- a/app/views/components/DescribeRoleRadios.scala.html
+++ b/app/views/components/DescribeRoleRadios.scala.html
@@ -1,0 +1,87 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import play.api.i18n.Messages
+
+@this()
+
+@(heading: String, content: Html, field: Field, messages: Messages)
+
+
+@employeeChecked = @{
+if(field.value.isDefined && field.value.get == "employeeOfOrg") {
+"checked"
+} else {
+""
+}
+}
+
+@agentOrgChecked = @{
+ if(field.value.isDefined && field.value.get == "agentOnBehalfOfOrg") {
+  "checked"
+ } else {
+  ""
+ }
+}
+
+@agentTraderChecked = @{
+ if(field.value.isDefined && field.value.get == "agentOnBehalfOfTrader") {
+  "checked"
+ } else {
+  ""
+ }
+}
+
+<fieldset class="govuk-fieldset govuk-!-margin-bottom-4">
+
+ <legend class="govuk-fieldset__legend  govuk-fieldset__legend--xl">
+  <h1 class="govuk-fieldset__heading">
+   @heading
+  </h1>
+ </legend>
+
+ @content
+
+ <div class="govuk-radios" data-module="govuk-radios">
+  <div class="govuk-radios__item">
+   <input class="govuk-radios__input" id="value_0" name="value" type="radio" value="employeeOfOrg" aria-describedby="value_0-item-hint" @employeeChecked>
+   <label class="govuk-label govuk-radios__label" for="value_0">
+    <b>@messages("whatIsYourRoleAsImporter.employeeOfOrg")</b>
+   </label>
+   <div id="value_0-item-hint" class="govuk-hint govuk-radios__hint">
+    Imports goods into the UK on behalf of their organisation.
+   </div>
+  </div>
+  <div class="govuk-radios__item">
+   <input class="govuk-radios__input" id="value_1" name="value" type="radio" value="agentOnBehalfOfOrg" aria-describedby="value_1-item-hint" @agentOrgChecked>
+   <label class="govuk-label govuk-radios__label" for="value_1">
+    <b>Agent acting on behalf of an organisation</b>
+   </label>
+   <div id="value_1-item-hint" class="govuk-hint govuk-radios__hint">
+    Imports goods into the UK on behalf of another organisation.
+   </div>
+  </div>
+  <div class="govuk-radios__item">
+   <input class="govuk-radios__input" id="value_2" name="value" type="radio" value="agentOnBehalfOfTrader" aria-describedby="value_2-item-hint" @agentTraderChecked>
+   <label class="govuk-label govuk-radios__label" for="value_2">
+    <b>Agent acting on behalf of a trader</b>
+   </label>
+   <div id="value_2-item-hint" class="govuk-hint govuk-radios__hint">
+    Imports goods into the UK on behalf of an individual trader.
+   </div>
+  </div>
+ </div>
+</fieldset>

--- a/app/views/components/DescribeRoleRadios.scala.html
+++ b/app/views/components/DescribeRoleRadios.scala.html
@@ -19,7 +19,7 @@
 @(heading: String, content: Html, form: Form[_])(implicit messages: Messages)
 
 
-@(role: String) = @{
+@role(role: String) = @{
  if (form("value").value.isDefined && form("value").value.get == role) {
   "checked"
  } else {
@@ -27,48 +27,76 @@
  }
 }
 
-@employeeChecked = @role("employeeOfOrg")
-@agentOrgChecked = @role("agentOnBehalfOfOrg")
-@agentTraderChecked = @role("agentOnBehalfOfTrader")
+@employeeChecked = @{role("employeeOfOrg")}
+@agentOrgChecked = @{role("agentOnBehalfOfOrg")}
+@agentTraderChecked = @{role("agentOnBehalfOfTrader")}
 
 
-<fieldset class="govuk-fieldset govuk-!-margin-bottom-4">
+@errorClassOrNot = @{
+ if(form.errors.nonEmpty) {
+  "govuk-form-group govuk-form-group--error"
+ } else {
+  "govuk-form-group"
+ }
+}
 
- <legend class="govuk-fieldset__legend  govuk-fieldset__legend--xl">
-  <h1 class="govuk-fieldset__heading">
-   @heading
-  </h1>
- </legend>
+@errorMessage = @{
+ if(form.errors.nonEmpty) {
+  <p id="value-error" class="govuk-error-message">
+   <span class="govuk-visually-hidden">Error:</span>
+   {form.errors.map {
+    error: FormError =>
+    messages(error.message)
+   }}
+  </p>
+ } else {
+  ""
+ }
+}
 
- @content
+<div class="@errorClassOrNot">
 
- <div class="govuk-radios" data-module="govuk-radios">
-  <div class="govuk-radios__item">
-   <input class="govuk-radios__input" id="value_0" name="value" type="radio" value="employeeOfOrg" aria-describedby="value_0-item-hint" @employeeChecked>
-   <label class="govuk-label govuk-radios__label" for="value_0">
-    <b>@messages("whatIsYourRoleAsImporter.employeeOfOrg")</b>
-   </label>
-   <div id="value_0-item-hint" class="govuk-hint govuk-radios__hint">
-    @messages("whatIsYourRoleAsImporter.employeeOfOrg.hint")
+ <fieldset class="govuk-fieldset govuk-!-margin-bottom-4">
+
+  <legend class="govuk-fieldset__legend  govuk-fieldset__legend--xl">
+   <h1 class="govuk-fieldset__heading">
+    @heading
+   </h1>
+  </legend>
+
+  @content
+
+  @errorMessage
+
+  <div class="govuk-radios" data-module="govuk-radios">
+   <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="value_0" name="value" type="radio" value="employeeOfOrg" aria-describedby="value_0-item-hint" @employeeChecked>
+    <label class="govuk-label govuk-radios__label" for="value_0">
+     <b>@messages("whatIsYourRoleAsImporter.employeeOfOrg")</b>
+    </label>
+    <div id="value_0-item-hint" class="govuk-hint govuk-radios__hint">
+     @messages("whatIsYourRoleAsImporter.employeeOfOrg.hint")
+    </div>
+   </div>
+   <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="value_1" name="value" type="radio" value="agentOnBehalfOfOrg" aria-describedby="value_1-item-hint" @agentOrgChecked>
+    <label class="govuk-label govuk-radios__label" for="value_1">
+     <b>@messages("whatIsYourRoleAsImporter.agentOnBehalfOfOrg")</b>
+    </label>
+    <div id="value_1-item-hint" class="govuk-hint govuk-radios__hint">
+     @messages("whatIsYourRoleAsImporter.agentOnBehalfOfOrg.hint")
+    </div>
+   </div>
+   <div class="govuk-radios__item">
+    <input class="govuk-radios__input" id="value_2" name="value" type="radio" value="agentOnBehalfOfTrader" aria-describedby="value_2-item-hint" @agentTraderChecked>
+    <label class="govuk-label govuk-radios__label" for="value_2">
+     <b>@messages("whatIsYourRoleAsImporter.agentOnBehalfOfTrader")</b>
+    </label>
+    <div id="value_2-item-hint" class="govuk-hint govuk-radios__hint">
+     @messages("whatIsYourRoleAsImporter.agentOnBehalfOfTrader.hint")
+    </div>
    </div>
   </div>
-  <div class="govuk-radios__item">
-   <input class="govuk-radios__input" id="value_1" name="value" type="radio" value="agentOnBehalfOfOrg" aria-describedby="value_1-item-hint" @agentOrgChecked>
-   <label class="govuk-label govuk-radios__label" for="value_1">
-    <b>@messages("whatIsYourRoleAsImporter.agentOnBehalfOfOrg")</b>
-   </label>
-   <div id="value_1-item-hint" class="govuk-hint govuk-radios__hint">
-    @messages("whatIsYourRoleAsImporter.agentOnBehalfOfOrg.hint")
-   </div>
-  </div>
-  <div class="govuk-radios__item">
-   <input class="govuk-radios__input" id="value_2" name="value" type="radio" value="agentOnBehalfOfTrader" aria-describedby="value_2-item-hint" @agentTraderChecked>
-   <label class="govuk-label govuk-radios__label" for="value_2">
-    <b>@messages("whatIsYourRoleAsImporter.agentOnBehalfOfTrader")</b>
-   </label>
-   <div id="value_2-item-hint" class="govuk-hint govuk-radios__hint">
-    @messages("whatIsYourRoleAsImporter.agentOnBehalfOfTrader.hint")
-   </div>
-  </div>
- </div>
-</fieldset>
+ </fieldset>
+
+</div>

--- a/app/views/components/LegendH2.scala.html
+++ b/app/views/components/LegendH2.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(message: String)
+
+<h2 class='govuk-fieldset__legend--m'>
+ @message
+</h2>

--- a/app/views/components/YesNoRadios.scala.html
+++ b/app/views/components/YesNoRadios.scala.html
@@ -18,7 +18,7 @@
 
 @(heading: String, content: Html, form: Form[_])(implicit messages: Messages)
 
-@(valueToCheck: String) = @{
+@valueToCheck(valueToCheck: String) = @{
  if (form("value").value.isDefined && form("value").value.get == valueToCheck) {
   "checked"
  } else {
@@ -26,8 +26,8 @@
  }
 }
 
-@yesChecked = @valueToCheck("true")
-@noChecked = @valueToCheck("false")
+@yesChecked = @{valueToCheck("true")}
+@noChecked = @{valueToCheck("false")}
 
 @errorClassOrNot = @{
  if(form.errors.nonEmpty) {
@@ -41,10 +41,10 @@
  if(form.errors.nonEmpty) {
   <p id="value-error" class="govuk-error-message">
    <span class="govuk-visually-hidden">Error:</span>
-     {form.errors.map {
-        error: FormError =>
-         messages(error.message)
-     }}
+    {form.errors.map {
+       error: FormError =>
+        messages(error.message)
+    }}
   </p>
  } else {
   ""

--- a/app/views/components/YesNoRadios.scala.html
+++ b/app/views/components/YesNoRadios.scala.html
@@ -16,46 +16,68 @@
 
 @this()
 
-@(heading: String, content: Html, field: Field)
+@(heading: String, content: Html, form: Form[_])(implicit messages: Messages)
 
-@yesChecked = @{
- if(field.value.isDefined && field.value.get == "true") {
+@(valueToCheck: String) = @{
+ if (form("value").value.isDefined && form("value").value.get == valueToCheck) {
   "checked"
  } else {
   ""
  }
 }
 
-@noChecked = @{
- if(field.value.isDefined && field.value.get == "false") {
-  "checked"
+@yesChecked = @valueToCheck("true")
+@noChecked = @valueToCheck("false")
+
+@errorClassOrNot = @{
+ if(form.errors.nonEmpty) {
+  "govuk-form-group govuk-form-group--error"
+ } else {
+  "govuk-form-group"
+ }
+}
+
+@errorMessage = @{
+ if(form.errors.nonEmpty) {
+  <p id="value-error" class="govuk-error-message">
+   <span class="govuk-visually-hidden">Error:</span>
+     {form.errors.map {
+        error: FormError =>
+         messages(error.message)
+     }}
+  </p>
  } else {
   ""
  }
 }
 
-<fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+<div class="@errorClassOrNot">
 
-<legend class="govuk-fieldset__legend  govuk-fieldset__legend--xl">
- <h1 class="govuk-fieldset__heading">
-  @heading
- </h1>
-</legend>
+ <fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
 
-@content
+ <legend class="govuk-fieldset__legend  govuk-fieldset__legend--xl">
+  <h1 class="govuk-fieldset__heading">
+   @heading
+  </h1>
+ </legend>
 
-<div class="govuk-radios" data-module="govuk-radios">
- <div class="govuk-radios__item">
-  <input class="govuk-radios__input" id="value" name="value" type="radio" value="true" @yesChecked>
-  <label class="govuk-label govuk-radios__label" for="value">
-  Yes
-  </label>
+ @content
+ @errorMessage
+
+ <div class="govuk-radios" data-module="govuk-radios">
+  <div class="govuk-radios__item">
+   <input class="govuk-radios__input" id="value" name="value" type="radio" value="true" @yesChecked>
+   <label class="govuk-label govuk-radios__label" for="value">
+    @messages("site.yes")
+   </label>
+  </div>
+  <div class="govuk-radios__item">
+   <input class="govuk-radios__input" id="value-no" name="value" type="radio" value="false" @noChecked>
+   <label class="govuk-label govuk-radios__label" for="value-no">
+    @messages("site.no")
+   </label>
+  </div>
  </div>
- <div class="govuk-radios__item">
-  <input class="govuk-radios__input" id="value-no" name="value" type="radio" value="false" @noChecked>
-  <label class="govuk-label govuk-radios__label" for="value-no">
-   No
-  </label>
- </div>
+ </fieldset>
+
 </div>
-</fieldset>

--- a/app/views/components/YesNoRadios.scala.html
+++ b/app/views/components/YesNoRadios.scala.html
@@ -1,0 +1,61 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(heading: String, content: Html, field: Field)
+
+@yesChecked = @{
+ if(field.value.isDefined && field.value.get == "true") {
+  "checked"
+ } else {
+  ""
+ }
+}
+
+@noChecked = @{
+ if(field.value.isDefined && field.value.get == "false") {
+  "checked"
+ } else {
+  ""
+ }
+}
+
+<fieldset class="govuk-fieldset govuk-!-margin-bottom-6">
+
+<legend class="govuk-fieldset__legend  govuk-fieldset__legend--xl">
+ <h1 class="govuk-fieldset__heading">
+  @heading
+ </h1>
+</legend>
+
+@content
+
+<div class="govuk-radios" data-module="govuk-radios">
+ <div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="value" name="value" type="radio" value="true" @yesChecked>
+  <label class="govuk-label govuk-radios__label" for="value">
+  Yes
+  </label>
+ </div>
+ <div class="govuk-radios__item">
+  <input class="govuk-radios__input" id="value-no" name="value" type="radio" value="false" @noChecked>
+  <label class="govuk-label govuk-radios__label" for="value-no">
+   No
+  </label>
+ </div>
+</div>
+</fieldset>


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

Legends have been added to all radio input fieldsets, and I can't find other cases where this is an issue. I'm confident there's no solution much cleaner than this. 

For a good few hours I looked at and experimented with the hmrc components and there isn't a way to allow content between the legend and the actual radio inputs. Our use case is unique in this way. This is loosely confirmed by Adam's comment "The fix is not trivial.".

I've implemented reusable components for radios where the legend is present and form errors are correctly displayed.