### PR TITLE
Upgraded PlayFrontendHmrcVersion to 7.23.0-play-28

### DIFF
--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -84,7 +84,6 @@
     serviceUrl = Some(routes.AccountHomeController.onPageLoad().url),
     signOutUrl = if(showSignOut) Some(controllers.auth.routes.AuthController.signOut().url) else None,
     phaseBanner = Some(standardBetaBanner(url = appConfig.feedbackUrl)),
-    nonce = CSPNonce.get,
     additionalScriptsBlock = Some(additionalScripts),
     additionalHeadBlock = Some(headBlock),
     mainContentLayout = mainContentLayout,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ object AppDependencies {
   import play.core.PlayVersion
 
   val HmrcMongoPlayVersion              = "1.2.0"
-  val PlayFrontendHmrcVersion           = "6.8.0-play-28"
+  val PlayFrontendHmrcVersion           = "7.23.0-play-28"
   val PlayConditionalFormMappingVersion = "1.12.0-play-28"
   val BootstrapFrontendPlayVersion      = "7.14.0"
   val CatsVersion                       = "2.9.0"


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [X] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Jira title](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-151)

Updated PlayFrontendHmrc to major version 7 

Only thing I had to change was that nonce is no longer a parameter in hmrcLayout

I think it gets it from the request now. That's what the changelog seems to imply 
https://github.com/hmrc/play-frontend-hmrc/blob/4a55049a878ada8c47ac378cae79a0006eb16a11/CHANGELOG.md?plain=1#L297