### PR TITLE
ARSSTB-427: Replace textareas with character count component

### DIFF
--- a/app/viewmodels/govuk/CharacterCountFluency.scala
+++ b/app/viewmodels/govuk/CharacterCountFluency.scala
@@ -21,6 +21,7 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
 import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.charactercount.CharacterCount
+
 import viewmodels.ErrorMessageAwareness
 
 object characterCount extends CharacterCountFluency
@@ -30,9 +31,9 @@ trait CharacterCountFluency {
   object CharacterCountViewModel extends ErrorMessageAwareness {
 
     def apply(
-               field: Field,
-               label: Label
-             )(implicit messages: Messages): CharacterCount =
+      field: Field,
+      label: Label
+    )(implicit messages: Messages): CharacterCount =
       CharacterCount(
         id = field.id,
         name = field.name,

--- a/app/viewmodels/govuk/CharacterCountFluency.scala
+++ b/app/viewmodels/govuk/CharacterCountFluency.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.govuk
+
+import play.api.data.Field
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
+import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.charactercount.CharacterCount
+import viewmodels.ErrorMessageAwareness
+
+object characterCount extends CharacterCountFluency
+
+trait CharacterCountFluency {
+
+  object CharacterCountViewModel extends ErrorMessageAwareness {
+
+    def apply(
+               field: Field,
+               label: Label
+             )(implicit messages: Messages): CharacterCount =
+      CharacterCount(
+        id = field.id,
+        name = field.name,
+        value = field.value,
+        label = label,
+        errorMessage = errorMessage(field)
+      )
+  }
+
+  implicit class FluentCharacterCount(characterCount: CharacterCount) {
+
+    def withMaxLength(maxLength: Int): CharacterCount =
+      characterCount.copy(maxLength = Some(maxLength))
+
+    def withMaxWords(maxWords: Int): CharacterCount =
+      characterCount.copy(maxWords = Some(maxWords))
+
+    def withId(id: String): CharacterCount =
+      characterCount.copy(id = id)
+
+    def withHint(hint: Hint): CharacterCount =
+      characterCount.copy(hint = Some(hint))
+
+    def withFormGroupClasses(classes: String): CharacterCount =
+      characterCount.copy(formGroupClasses = classes)
+
+    def withCssClass(newClass: String): CharacterCount =
+      characterCount.copy(classes = s"${characterCount.classes} $newClass")
+
+    def withAttribute(attribute: (String, String)): CharacterCount =
+      characterCount.copy(attributes = characterCount.attributes + attribute)
+
+    def withSpellcheck(on: Boolean = true): CharacterCount =
+      characterCount.copy(spellcheck = Some(on))
+
+    def withSize(size: String): CharacterCount =
+      characterCount.withCssClass(size)
+
+    def withRows(rows: Int): CharacterCount =
+      characterCount.copy(rows = rows)
+
+    def withThreshold(threshold: Int): CharacterCount =
+      characterCount.copy(threshold = Some(threshold))
+  }
+}

--- a/app/viewmodels/govuk/LabelFluency.scala
+++ b/app/viewmodels/govuk/LabelFluency.scala
@@ -38,11 +38,6 @@ trait LabelFluency {
         .copy(isPageHeading = true)
         .withCssClass(size.toString)
 
-    def asLegendHeading(): Label =
-      label
-        .copy(isPageHeading = false)
-        .withCssClass(LabelSize.Medium.toString)
-
     def withCssClass(className: String): Label =
       label copy (classes = s"${label.classes} $className")
 
@@ -51,5 +46,11 @@ trait LabelFluency {
 
     def forAttr(attr: String): Label =
       label copy (forAttr = Some(attr))
+
+    def withSize(size: LabelSize): Label =
+      label.withCssClass(size.toString)
+
+    def visuallyHidden(): Label =
+      label.withCssClass("govuk-visually-hidden")
   }
 }

--- a/app/viewmodels/govuk/package.scala
+++ b/app/viewmodels/govuk/package.scala
@@ -22,6 +22,7 @@ package object govuk {
       extends ImplicitConversions
       with BackLinkFluency
       with ButtonFluency
+      with CharacterCountFluency
       with CheckboxFluency
       with DateFluency
       with ErrorSummaryFluency

--- a/app/views/ApplicationCompleteView.scala.html
+++ b/app/views/ApplicationCompleteView.scala.html
@@ -22,7 +22,6 @@
     layout: templates.Layout,
     govukErrorSummary: GovukErrorSummary,
     govukButton: GovukButton,
-    govukTextarea: GovukTextarea,
     govukSummaryList: GovukSummaryList,
     bulletList: BulletList,
     link: Link,
@@ -34,7 +33,6 @@
     config: FrontendAppConfig,
     govukPanel: GovukPanel
 )
-
 
  @(isIndividual: Boolean, applicationId: String, email: String)(implicit request: Request[_], messages: Messages)
 

--- a/app/views/ConfidentialInformationView.scala.html
+++ b/app/views/ConfidentialInformationView.scala.html
@@ -20,7 +20,7 @@
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     bulletList: BulletList,
     cancelApplicationLink: CancelApplicationLink,
     caption: Caption,
@@ -53,15 +53,16 @@
 
         @caption(messages("confidentialInformation.caption"))
 
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("confidentialInformation.heading")).asPageHeading()
-                )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
-                .withHint(Hint(content = HtmlContent(paraContent)))
-                .withId("value")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withHint(Hint(content = HtmlContent(paraContent)))
+            .withId("value")
+            .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/DescribeTheConditionsView.scala.html
+++ b/app/views/DescribeTheConditionsView.scala.html
@@ -20,7 +20,7 @@
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
     caption: Caption,
@@ -44,15 +44,16 @@
 
         @caption(messages("describeTheConditions.caption"))
 
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("describeTheConditions.heading")).asPageHeading()
-                )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
-                .withHint(Hint(content = HtmlContent(paraContent)))
-                .withId("value")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withHint(Hint(content = HtmlContent(paraContent)))
+            .withId("value")
+            .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/DescribeTheIdenticalGoodsView.scala.html
+++ b/app/views/DescribeTheIdenticalGoodsView.scala.html
@@ -22,7 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     list: BulletList,
     paragraph: Paragraph,
     caption: Caption,
@@ -55,15 +55,16 @@
     @caption(messages("describeTheIdenticalGoods.caption"))
 
 
-    @govukTextarea(
-        TextareaViewModel(
+    @hmrcCharacterCount(
+        CharacterCountViewModel(
             field = form("value"),
             label = LabelViewModel(messages("describeTheIdenticalGoods.heading")).asPageHeading()
-            )
-            .withRows(15)
-            .withAttribute("maxlength","8167")
-            .withHint(Hint(content = HtmlContent(paraContent)))
-            .withId("value")
+        )
+        .withRows(15)
+        .withMaxLength(8167)
+        .withHint(Hint(content = HtmlContent(paraContent)))
+        .withId("value")
+        .withThreshold(75)
     )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/DescribeTheLegalChallengesView.scala.html
+++ b/app/views/DescribeTheLegalChallengesView.scala.html
@@ -21,7 +21,7 @@
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     cancelLink: CancelApplicationLink,
     caption: Caption,
     heading: Heading,
@@ -44,15 +44,16 @@
 
         @caption(messages("describeTheLegalChallenges.caption"))
 
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("describeTheLegalChallenges.heading")).asPageHeading()
-                )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
-                .withHint(Hint(content = HtmlContent(paraContent)))
-                .withId("value")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withHint(Hint(content = HtmlContent(paraContent)))
+            .withId("value")
+            .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/DescribeTheRestrictionsView.scala.html
+++ b/app/views/DescribeTheRestrictionsView.scala.html
@@ -20,7 +20,7 @@
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
     caption: Caption,
@@ -44,15 +44,16 @@
 
         @caption(messages("describeTheRestrictions.caption"))
 
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("describeTheRestrictions.heading")).asPageHeading()
-                )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
-                .withHint(Hint(content = HtmlContent(paraContent)))
-                .withId("value")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withHint(Hint(content = HtmlContent(paraContent)))
+            .withId("value")
+            .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/DescribeTheSimilarGoodsView.scala.html
+++ b/app/views/DescribeTheSimilarGoodsView.scala.html
@@ -21,7 +21,7 @@
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
     caption: Caption,
@@ -55,15 +55,16 @@
 
         @caption(messages("describeTheSimilarGoods.caption"))
 
-         @govukTextarea(
-            TextareaViewModel(
+         @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("describeTheSimilarGoods.heading")).asPageHeading()
-                )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
-                .withHint(Hint(content = HtmlContent(paraContent)))
-                .withId("value")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withHint(Hint(content = HtmlContent(paraContent)))
+            .withId("value")
+            .withThreshold(75)
 
         )
 

--- a/app/views/ExplainHowPartiesAreRelatedView.scala.html
+++ b/app/views/ExplainHowPartiesAreRelatedView.scala.html
@@ -22,7 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
@@ -50,15 +50,16 @@
 
         @caption(messages("explainHowPartiesAreRelated.caption"))
 
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("explainHowPartiesAreRelated.heading")).asPageHeading()
-                )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
-                .withHint(Hint(content = HtmlContent(paraAndSubheadingContent)))
-                .withId("value")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withHint(Hint(content = HtmlContent(paraAndSubheadingContent)))
+            .withId("value")
+            .withThreshold(75)
 
         )
 

--- a/app/views/ExplainHowYouWillUseMethodSixView.scala.html
+++ b/app/views/ExplainHowYouWillUseMethodSixView.scala.html
@@ -21,7 +21,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     list: BulletList,
     paragraph: Paragraph,
     caption: Caption,
@@ -47,15 +47,16 @@
 
         @caption(messages("explainHowYouWillUseMethodSix.caption"))
 
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = LabelViewModel(messages("explainHowYouWillUseMethodSix.heading")).asPageHeading()
-                )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
-                .withHint(Hint(content = HtmlContent(paraContent)))
-                .withId("value")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withHint(Hint(content = HtmlContent(paraContent)))
+            .withId("value")
+            .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/ExplainReasonComputedValueView.scala.html
+++ b/app/views/ExplainReasonComputedValueView.scala.html
@@ -22,7 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
@@ -47,15 +47,16 @@
 
     @caption(messages("explainReasonComputedValue.caption"))
 
-    @govukTextarea(
-        TextareaViewModel(
+    @hmrcCharacterCount(
+        CharacterCountViewModel(
             field = form("value"),
             label = LabelViewModel(messages("explainReasonComputedValue.heading")).asPageHeading()
-            )
-            .withRows(15)
-            .withAttribute("maxlength","8167")
-            .withHint(Hint(content = HtmlContent(paraContent)))
-            .withId("value")
+        )
+        .withRows(15)
+        .withMaxLength(8167)
+        .withHint(Hint(content = HtmlContent(paraContent)))
+        .withId("value")
+        .withThreshold(75)
     )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/ExplainWhyYouChoseMethodFourView.scala.html
+++ b/app/views/ExplainWhyYouChoseMethodFourView.scala.html
@@ -16,13 +16,14 @@
 
 @import viewmodels.InputWidth._
 @import components._
+@import viewmodels.LabelSize.Medium
 
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     caption: Caption,
     paragraph: Paragraph,
     heading: Heading,
@@ -53,16 +54,17 @@
 
     @paragraph(Html(messages("explainWhyYouChoseMethodFour.paragraph.3")))
 
-    @govukTextarea(
-        TextareaViewModel(
+    @hmrcCharacterCount(
+        CharacterCountViewModel(
             field = form("value"),
             label = Label(
                 content = Text(messages("explainWhyYouChoseMethodFour.label")),
             )
-            .asLegendHeading()
+            .withSize(Medium)
         )
         .withRows(15)
-        .withAttribute("maxlength","8167")
+        .withMaxLength(8167)
+        .withThreshold(75)
     )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/ExplainWhyYouHaveNotSelectedMethodOneToFiveView.scala.html
+++ b/app/views/ExplainWhyYouHaveNotSelectedMethodOneToFiveView.scala.html
@@ -21,7 +21,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     list: BulletList,
     paragraph: Paragraph,
     caption: Caption,
@@ -60,17 +60,17 @@
         )
         @paragraph(Html(messages("explainWhyYouHaveNotSelectedMethodOneToFive.paragraph.2")))
 
-
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = Label(
                     content = Text(messages("explainWhyYouHaveNotSelectedMethodOneToFive.label")),
                     classes = "govuk-visually-hidden",
-                    )
                 )
-                .withRows(15)
-                .withAttribute("maxlength","8167")
+            )
+            .withRows(15)
+            .withMaxLength(8167)
+            .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/ExplainWhyYouHaveNotSelectedMethodOneToThreeView.scala.html
+++ b/app/views/ExplainWhyYouHaveNotSelectedMethodOneToThreeView.scala.html
@@ -22,7 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     list: BulletList,
     paragraph: Paragraph,
     caption: Caption,
@@ -60,8 +60,8 @@
         @paragraph(Html(messages("explainWhyYouHaveNotSelectedMethodOneToThree.paragraph.2")))
 
 
-        @govukTextarea(
-            TextareaViewModel(
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = Label(
                     content = Text(messages("explainWhyYouHaveNotSelectedMethodOneToThree.label")),
@@ -69,7 +69,8 @@
                     )
                 )
                 .withRows(15)
-                .withAttribute("maxlength","8167")
+                .withMaxLength(8167)
+                .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/TellUsAboutYourRulingView.scala.html
+++ b/app/views/TellUsAboutYourRulingView.scala.html
@@ -15,16 +15,13 @@
  *@
 
 @import components._
-@import uk.gov.hmrc.hmrcfrontend.views.html.components.{CharacterCount => CharCount}
 @import uk.gov.hmrc.hmrcfrontend.views.html.components._
-@import uk.gov.hmrc.hmrcfrontend.views.html.components.implicits._
 
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
     hmrcCharacterCount: HmrcCharacterCount,
     list: BulletList,
     paragraph: Paragraph,
@@ -61,20 +58,18 @@
         @caption(messages("caption.goods"))
         @heading(messages("tellUsAboutYourRuling.heading"))
 
-        @hmrcCharacterCount(CharCount(
-            id = "value",
-            name = "value",
-            maxLength = Some(8000),
-            rows = 10,
-            label = Label(
-                content = Text(messages("tellUsAboutYourRuling.label")),
-                classes = "govuk-visually-hidden"
-            ),
-            hint = Some(Hint(content = HtmlContent(content))),
-            value = form("value").value,
-            errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
-        ))
-
+        @hmrcCharacterCount(
+            CharacterCountViewModel(
+                field = form("value"),
+                label = Label(
+                    content = Text(messages("tellUsAboutYourRuling.label")),
+                ).visuallyHidden()
+            )
+            .withRows(10)
+            .withMaxLength(8000)
+            .withThreshold(75)
+            .withHint(HintViewModel(content = HtmlContent(content)))
+        )
 
         @saveButtons(draftId, onSubmitAction())
     }

--- a/app/views/WhyComputedValueView.scala.html
+++ b/app/views/WhyComputedValueView.scala.html
@@ -22,7 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
@@ -58,8 +58,8 @@
 
     @paragraph(Html(messages("whyComputedValue.paragraph.2")))
 
-    @govukTextarea(
-            TextareaViewModel(
+    @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = Label(
                     content = Text(messages("whyComputedValue.label")),
@@ -67,7 +67,8 @@
                     )
                 )
                 .withRows(15)
-                .withAttribute("maxlength","8167")
+                .withMaxLength(8167)
+                .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/WhyIdenticalGoodsView.scala.html
+++ b/app/views/WhyIdenticalGoodsView.scala.html
@@ -22,7 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     paragraph: Paragraph,
     bulletList: BulletList,
     caption: Caption,
@@ -52,15 +52,16 @@
 
     @caption(messages("whyIdenticalGoods.caption"))
 
-    @govukTextarea(
-        TextareaViewModel(
+    @hmrcCharacterCount(
+        CharacterCountViewModel(
             field = form("value"),
             label = LabelViewModel(messages("whyIdenticalGoods.heading")).asPageHeading()
-            )
-            .withRows(15)
-            .withAttribute("maxlength","8167")
-            .withHint(Hint(content = HtmlContent(paraContent)))
-            .withId("value")
+        )
+        .withRows(15)
+        .withMaxLength(8167)
+        .withHint(Hint(content = HtmlContent(paraContent)))
+        .withId("value")
+        .withThreshold(75)
     )
 
         @saveButtons(draftId, onSubmitAction())

--- a/app/views/WhyTransactionValueOfSimilarGoodsView.scala.html
+++ b/app/views/WhyTransactionValueOfSimilarGoodsView.scala.html
@@ -21,7 +21,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukTextarea: GovukTextarea,
+    hmrcCharacterCount: HmrcCharacterCount,
     cancelLink: CancelApplicationLink,
     paragraph: Paragraph,
     caption: Caption,
@@ -55,8 +55,8 @@
 
     @paragraph(Html(messages("whyTransactionValueOfSimilarGoods.paragraph.2")))
 
-    @govukTextarea(
-            TextareaViewModel(
+    @hmrcCharacterCount(
+            CharacterCountViewModel(
                 field = form("value"),
                 label = Label(
                     content = Text(messages("whyTransactionValueOfSimilarGoods.label")),
@@ -64,7 +64,8 @@
                     )
                 )
                 .withRows(15)
-                .withAttribute("maxlength","8167")
+                .withMaxLength(8167)
+                .withThreshold(75)
         )
 
         @saveButtons(draftId, onSubmitAction())

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -242,7 +242,7 @@ explainHowPartiesAreRelated.para.1 = Gallwn ond a derbyn y pris a dalwyd neu sy�
 explainHowPartiesAreRelated.para.2 = Bydd rhoi disgrifiad manwl o’r cysylltiad yn ein helpu ni i brosesu’ch cais cyn gynted â phosibl.
 explainHowPartiesAreRelated.error.required = Nodwch ddisgrifiad o’r cysylltiad rhwng y partïon
 explainHowPartiesAreRelated.checkYourAnswersLabel = Disgrifiwch beth yw’r cysylltiad rhwng y partïon
-explainHowPartiesAreRelated.error.length = Maximum allowed characters is 8168
+explainHowPartiesAreRelated.error.length = Mae’n rhaid i’r disgrifiad o sut mae’r partïon yn gysylltiedig fod yn 8,167 o gymeriadau neu lai
 explainHowPartiesAreRelated.change.hidden = your description of how the parties are related
 explainHowPartiesAreRelated.question = Can you describe how the parties are related?
 
@@ -264,7 +264,7 @@ describeTheRestrictions.heading = Disgrifiwch unrhyw gyfyngiadau o ran defnyddio
 describeTheRestrictions.label = Disgrifiwch unrhyw gyfyngiadau o ran defnyddio neu ailwerthu’r nwyddau
 describeTheRestrictions.checkYourAnswersLabel = Disgrifiad o’r cyfyngiadau
 describeTheRestrictions.error.required = Nodwch ddisgrifiad o’r cyfyngiadau sydd ar waith
-describeTheRestrictions.error.length = Maximum allowed characters is 8168
+describeTheRestrictions.error.length = Mae’n rhaid i’r disgrifiad o’r cyfyngiadau fod yn 8,167 o gymeriadau neu lai
 describeTheRestrictions.paragraph.1 = Bydd rhoi disgrifiad manwl o’r cysylltiad yn ein helpu ni i brosesu’ch cais cyn gynted â phosibl
 describeTheRestrictions.change.hidden = your description of the restrictions on the use/resale of the goods
 
@@ -286,7 +286,7 @@ describeTheConditions.heading = Disgrifiwch yr amodau neu’r amgylchiadau na el
 describeTheConditions.label = Disgrifiwch yr amodau neu’r amgylchiadau na ellir eu cyfrifo
 describeTheConditions.checkYourAnswersLabel = Disgrifiad o’r amodau/amgylchiadau
 describeTheConditions.error.required = Nodwch ddisgrifiad o unrhyw amodau neu amgylchiadau na allant gael eu cyfrifo
-describeTheConditions.error.length = Maximum allowed characters is 8168
+describeTheConditions.error.length = Mae’n rhaid i’r disgrifiad o’r amgylchiadau fod yn 8,167 o gymeriadau neu lai
 describeTheConditions.paragraph.1 = Bydd rhoi disgrifiad manwl o’r cysylltiad yn ein helpu ni i brosesu’ch cais cyn gynted â phosibl.
 describeTheConditions.change.hidden = your description of the conditions or circumstances which cannot be calculated
 
@@ -299,7 +299,7 @@ whyIdenticalGoods.bulletPoint.1 = Dull 1 (gwerth trafodiad y nwyddau a fewnforiw
 whyIdenticalGoods.paragraph.2 = Esboniwch pam rydych o’r farn nad yw Dull 1 yn addas i gyfrifo gwerth tollau eich nwyddau.
 whyIdenticalGoods.checkYourAnswersLabel = Y rheswm dros beidio â dewis Dull 1 i brisio’ch nwyddau
 whyIdenticalGoods.error.required = Nodwch esboniad ynghylch pam na wnaethoch ddewis Dull 1 i brisio’ch nwyddau
-whyIdenticalGoods.error.length = Maximum allowed characters is 8168
+whyIdenticalGoods.error.length = Mae’n rhaid i’r esboniad o pam nad ydych wedi defnyddio Dull 1 fod yn 8,167 o gymeriadau neu lai
 whyIdenticalGoods.change.hidden = your reason for not selecting Method 1 to value the goods
 
 haveYouUsedMethodOneInPast.caption = Ynglŷn â’r nwyddau
@@ -326,7 +326,7 @@ describeTheIdenticalGoods.bulletPoint.2 = wedi’u hallforio i’r DU ar neu o g
 describeTheIdenticalGoods.bulletPoint.3 = yn union yr un fath ym mhob ffordd gan gynnwys nodweddion ffisegol, ansawdd ac enw da – nid yw mân wahaniaethau o ran golwg yn bwysig
 describeTheIdenticalGoods.checkYourAnswersLabel = Disgrifiad o’r nwyddau unfath
 describeTheIdenticalGoods.error.required = Nodwch ddisgrifiad o’r nwyddau unfath
-describeTheIdenticalGoods.error.length = Maximum allowed characters is 8168
+describeTheIdenticalGoods.error.length = Mae’n rhaid i’r disgrifiad o nwyddau unfath fod yn 8,167 o gymeriadau neu lai
 describeTheIdenticalGoods.change.hidden = your description of the identical goods
 
 whyTransactionValueOfSimilarGoods.caption = Ynglŷn â’r nwyddau
@@ -338,7 +338,7 @@ whyTransactionValueOfSimilarGoods.paragraph.2 = Esboniwch pam rydych o’r farn 
 whyTransactionValueOfSimilarGoods.bulletPoint.1 = Dull 1 (gwerth trafodiad y nwyddau a fewnforiwyd)
 whyTransactionValueOfSimilarGoods.bulletPoint.2 = Dull 2 (gwerth trafodiad y nwyddau unfath a fewnforiwyd)
 whyTransactionValueOfSimilarGoods.error.required = Nodwch esboniad ynghylch pam na wnaethoch ddewis Dull 1 na 2 i brisio’ch nwyddau
-whyTransactionValueOfSimilarGoods.error.length = Maximum allowed characters is 8168
+whyTransactionValueOfSimilarGoods.error.length = Mae’n rhaid i’r esboniad o pam nad ydych wedi defnyddio Dull 1 na 2 fod yn 8,167 o gymeriadau neu lai
 whyTransactionValueOfSimilarGoods.checkYourAnswersLabel = Y rheswm dros beidio â dewis Dulliau 1 neu 2 i brisio’ch nwyddau
 whyTransactionValueOfSimilarGoods.change.hidden = your reason for not selecting Methods 1-2 to value the goods
 
@@ -368,7 +368,7 @@ describeTheSimilarGoods.bulletPoint.2 = gall y nwyddau gyflawni’r un tasgau
 describeTheSimilarGoods.bulletPoint.3 = mae’r nwyddau’n fasnachol gyfnewidiol
 describeTheSimilarGoods.checkYourAnswersLabel = Description of similar goods
 describeTheSimilarGoods.error.required = Nodwch ddisgrifiad o’r nwyddau tebyg
-describeTheSimilarGoods.error.length = Maximum allowed characters is 8168
+describeTheSimilarGoods.error.length = Mae’n rhaid i’r disgrifiad o nwyddau tebyg fod yn 8,167 o gymeriadau neu lai
 describeTheSimilarGoods.change.hidden = your description of the similar goods
 
 explainWhyYouHaveNotSelectedMethodOneToThree.caption = Ynglŷn â’r nwyddau
@@ -382,7 +382,7 @@ explainWhyYouHaveNotSelectedMethodOneToThree.bulletPoint.3 = Dull 3 (gwerth traf
 explainWhyYouHaveNotSelectedMethodOneToThree.paragraph.2 = Esboniwch pam rydych o’r farn nad yw Dulliau 1-3 yn addas i gyfrifo gwerth tollau eich nwyddau.
 explainWhyYouHaveNotSelectedMethodOneToThree.checkYourAnswersLabel = Rheswm dros beidio â dewis Dulliau 1-3 i brisio’ch nwyddau
 explainWhyYouHaveNotSelectedMethodOneToThree.error.required = Nodwch esboniad ynghylch pam na wnaethoch ddewis dulliau 1 i 3 i brisio’ch nwyddau
-explainWhyYouHaveNotSelectedMethodOneToThree.error.length = Maximum allowed characters is 8168
+explainWhyYouHaveNotSelectedMethodOneToThree.error.length = Mae’n rhaid i’r esboniad o pam nad ydych wedi defnyddio Dulliau 1 i 3 fod yn 8,167 o gymeriadau neu lai
 explainWhyYouHaveNotSelectedMethodOneToThree.change.hidden = your reason for not selecting Methods 1-3 to value the goods
 
 explainWhyYouChoseMethodFour.caption = Ynglŷn â’r nwyddau
@@ -394,7 +394,7 @@ explainWhyYouChoseMethodFour.paragraph.2 = Gallwch ond defnyddio Dull 4 os bydd 
 explainWhyYouChoseMethodFour.paragraph.3 = Mae ‘heb gysylltiad’ yn golygu nad oes perthynas neu gysylltiad cyffredin rhwng y ddau gwmni.
 explainWhyYouChoseMethodFour.checkYourAnswersLabel = Rheswm dros ddewis Dull 4 i brisio’ch nwyddau
 explainWhyYouChoseMethodFour.error.required = Nodwch esboniad ynghylch pam yr ydych wedi dewis Dull 4 i brisio’ch nwyddau
-explainWhyYouChoseMethodFour.error.length = Maximum allowed characters is 8168
+explainWhyYouChoseMethodFour.error.length = Mae’n rhaid i’r esboniad o pam rydych wedi defnyddio Dull 4 fod yn 8,167 o gymeriadau neu lai
 explainWhyYouChoseMethodFour.change.hidden = your reason for selecting Method 4 to value the goods
 
 whyComputedValue.caption = Ynglŷn â’r nwyddau
@@ -409,7 +409,7 @@ whyComputedValue.bulletPoint.4 = Dull 4 (dull casgliadol)
 whyComputedValue.paragraph.2 = Esboniwch pam ydych o’r farn nad yw Dulliau 1-4 yn addas i gyfrifo gwerth tollau eich nwyddau.
 whyComputedValue.checkYourAnswersLabel = Rheswm dros beidio â dewis Dulliau 1-4 i brisio’ch nwyddau
 whyComputedValue.error.required = Nodwch esboniad ynghylch pam na wnaethoch ddewis dulliau 1 i 4 i brisio’ch nwyddau
-whyComputedValue.error.length = Maximum allowed characters is 8168
+whyComputedValue.error.length = Mae’n rhaid i’r esboniad o pam nad ydych wedi defnyddio Dulliau 1 i 4 fod yn 8,167 o gymeriadau neu lai
 whyComputedValue.change.hidden = your reason for not selecting Methods 1-4 to value the goods
 
 explainReasonComputedValue.caption = Ynglŷn â’r nwyddau
@@ -419,7 +419,7 @@ explainReasonComputedValue.label = Esboniwch pam rydych wedi dewis Dull 5 i bris
 explainReasonComputedValue.paragraph = Mae Dull 5 (dull cyfrifiadurol) yn seiliedig ar gostau cynhyrchu’r nwyddau.
 explainReasonComputedValue.checkYourAnswersLabel = Rheswm dros ddewis Dull 5 i brisio’ch nwyddau
 explainReasonComputedValue.error.required = Nodwch esboniad ynghylch pam yr ydych wedi dewis Dull 5 i brisio’ch nwyddau
-explainReasonComputedValue.error.length = Maximum allowed characters is 8168
+explainReasonComputedValue.error.length = Mae’n rhaid i’r esboniad o pam rydych wedi defnyddio Dull 5 fod yn 8,167 o gymeriadau neu lai
 explainReasonComputedValue.change.hidden = your reason for selecting Method 5 to value the goods
 
 explainWhyYouHaveNotSelectedMethodOneToFive.caption = Ynglŷn â’r nwyddau
@@ -428,7 +428,7 @@ explainWhyYouHaveNotSelectedMethodOneToFive.heading = Eglurwch pam nad ydych wed
 explainWhyYouHaveNotSelectedMethodOneToFive.label = Eglurwch pam nad ydych wedi dewis Dulliau 1-5 i brisio’ch nwyddau
 explainWhyYouHaveNotSelectedMethodOneToFive.checkYourAnswersLabel = Rheswm dros beidio â dewis Dulliau 1-5 i brisio’ch nwyddau
 explainWhyYouHaveNotSelectedMethodOneToFive.error.required = Nodwch esboniad ynghylch pam na wnaethoch ddewis dulliau 1 i 5 i brisio’ch nwyddau
-explainWhyYouHaveNotSelectedMethodOneToFive.error.length = Maximum allowed characters is 8168
+explainWhyYouHaveNotSelectedMethodOneToFive.error.length = Mae’n rhaid i’r esboniad o pam nad ydych wedi defnyddio Dulliau 1 i 5 fod yn 8,167 o gymeriadau neu lai
 explainWhyYouHaveNotSelectedMethodOneToFive.paragraph.1 = Dull 6 yw’r dull ‘wrth gefn’ i’w ddefnyddio pan na fyddwch yn gallu defnyddio unrhyw un o’r dulliau eraill. Cyn i chi ddefnyddio Dull 6 mae’n rhaid eich bod wedi rhoi cynnig ar y canlynol yn gyntaf:
 explainWhyYouHaveNotSelectedMethodOneToFive.bulletPoint.1 = Dull 1 (gwerth trafodiad y nwyddau a fewnforiwyd)
 explainWhyYouHaveNotSelectedMethodOneToFive.bulletPoint.2 = Dull 2 (gwerth trafodiad nwyddau unfath)
@@ -458,7 +458,7 @@ explainHowYouWillUseMethodSix.heading = Esboniwch sut rydych wedi defnyddio Dull
 explainHowYouWillUseMethodSix.label = Esboniwch sut rydych wedi defnyddio Dull 6 i brisio’ch nwyddau
 explainHowYouWillUseMethodSix.checkYourAnswersLabel = Esboniad o sut rydych wedi defnyddio Dull 6 i brisio’ch nwyddau
 explainHowYouWillUseMethodSix.error.required = Nodwch esboniad ynghylch sut yr ydych wedi defnyddio Dull 6 i brisio’ch nwyddau
-explainHowYouWillUseMethodSix.error.length = Maximum allowed characters is 8168
+explainHowYouWillUseMethodSix.error.length = Mae’n rhaid i’r esboniad o pam rydych wedi defnyddio Dull 6 fod yn 8,167 o gymeriadau neu lai
 explainHowYouWillUseMethodSix.paragraph.1 = Dull 6 (y dull wrth gefn) yw’r math olaf o ddull y gallwch roi cynnig arno.
 explainHowYouWillUseMethodSix.paragraph.2 = Disgrifiwch sut rydych yn bwriadu defnyddio Dull 6. Dylech hefyd roi gwybod i ni os ydych am addasu dull arall ar gyfer eich amgylchiadau chi.
 explainHowYouWillUseMethodSix.change.hidden = your explanation of how you have used Method 6 to value the goods
@@ -521,7 +521,7 @@ describeTheLegalChallenges.label = Disgrifiwch yr heriau cyfreithiol sy’n bert
 describeTheLegalChallenges.para = Bydd rhoi disgrifiad manwl o’r heriau cyfreithiol yn ein helpu ni i brosesu’ch cais cyn gynted â phosibl.
 describeTheLegalChallenges.checkYourAnswersLabel = Disgrifiad o’r heriau cyfreithiol
 describeTheLegalChallenges.error.required = Nodwch ddisgrifiad o’r heriau cyfreithiol sy’n ymwneud â’r nwyddau
-describeTheLegalChallenges.error.length = Maximum allowed characters is 8168
+describeTheLegalChallenges.error.length = Mae’n rhaid i’r disgrifiad o heriau cyfreithiol sy’n berthnasol i’r nwyddau fod yn 8,167 o gymeriadau neu lai
 describeTheLegalChallenges.change.hidden = your description of the legal challenges
 
 hasConfidentialInformation.caption = Ynglŷn â’r nwyddau
@@ -541,7 +541,7 @@ confidentialInformation.label = Disgrifiwch unrhyw wybodaeth gyfrinachol yr hoff
 confidentialInformation.caption = Ynglŷn â’r nwyddau
 confidentialInformation.checkYourAnswersLabel = Disgrifiad o’r wybodaeth gyfrinachol
 confidentialInformation.error.required = Nodwch ddisgrifiad o’r wybodaeth gyfrinachol yr hoffech ei hychwanegu am y nwyddau
-confidentialInformation.error.length = Maximum allowed characters is 8168
+confidentialInformation.error.length = Mae’n rhaid i’r disgrifiad o’r wybodaeth gyfrinachol fod yn 8,167 o gymeriadau neu lai
 confidentialInformation.change.hidden = describe confidential information
 confidentialInformation.paragraph.1 = Gall gwybodaeth gyfrinachol gynnwys:
 confidentialInformation.paragraph.2 = Ni fyddwn yn cyhoeddi gwybodaeth gyfrinachol.
@@ -911,7 +911,7 @@ explainYourGoodsComparingToIdenticalGoods.bulletPoint.1 = you do not think Metho
 explainYourGoodsComparingToIdenticalGoods.bulletPoint.2 = you do not have any further information about the identical goods
 explainYourGoodsComparingToIdenticalGoods.checkYourAnswersLabel = Esboniad o sut rydych yn defnyddio nwyddau unfath cynhyrchydd arall er mwyn cymharu
 explainYourGoodsComparingToIdenticalGoods.error.required = Enter an explanation about how you are comparing your goods to identical goods imported by another buyer or seller in the past 90 days
-explainYourGoodsComparingToIdenticalGoods.error.length = Maximum allowed characters is 8168
+explainYourGoodsComparingToIdenticalGoods.error.length = Mae’n rhaid i’r esboniad fod yn 8,167 o gymeriadau neu lai
 explainYourGoodsComparingToIdenticalGoods.change.hidden = your explanation of how you are using another producer’s identical goods for comparison
 
 willYouCompareGoodsToIdenticalGoods.title = Will you be comparing your goods to identical goods imported by another buyer or seller in the past 90-days?
@@ -1069,7 +1069,7 @@ tellUsAboutYourRuling.bulletPoint.3 = y dyddiad y cafodd y dyfarniad ei roi
 tellUsAboutYourRuling.bulletPoint.4 = dyddiad dod i ben ar gyfer y dyfarniad
 tellUsAboutYourRuling.error.required = Rhowch wybod i ni am y dyfarniad
 
-textCount.tooLong = Mae’n rhaid i’r disgrifiad o’r dyfarniadau fod yn 8000 o gymeriadau neu lai
+textCount.tooLong = Mae’n rhaid i’r disgrifiad o’r dyfarniadau fod yn 8,000 o gymeriadau neu lai
 
 aboutSimilarGoods.para.1 = Gall y rhain fod yn:
 aboutSimilarGoods.para.2 = Rhowch gymaint o wybodaeth ag y gallwch, megis:

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -348,7 +348,7 @@ confidentialInformation.label = Describe any confidential information you would 
 confidentialInformation.caption = About the goods
 confidentialInformation.checkYourAnswersLabel = Description of confidential information	
 confidentialInformation.error.required = Enter a description of the confidential information you would like to add about the goods
-confidentialInformation.error.length = Maximum allowed characters is 8168
+confidentialInformation.error.length = Description of confidential information must be 8,167 characters or less
 confidentialInformation.change.hidden = describe confidential information
 confidentialInformation.paragraph.1 = Confidential information can include:
 confidentialInformation.paragraph.2 = We will not publish confidential information.
@@ -591,7 +591,7 @@ explainReasonComputedValue.label = Explain why you have selected Method 5 to val
 explainReasonComputedValue.paragraph = Method 5 (computed value) is based on the costs of production of the goods.
 explainReasonComputedValue.checkYourAnswersLabel = Reason for selecting Method 5 to value your goods	
 explainReasonComputedValue.error.required = Enter an explanation about why you have selected Method 5 to value your goods
-explainReasonComputedValue.error.length = Maximum allowed characters is 8168
+explainReasonComputedValue.error.length = Explanation of why you have used Method 5 must be 8,167 characters or less
 explainReasonComputedValue.change.hidden = your reason for selecting Method 5 to value the goods
 
 whyComputedValue.title = Explain why you have not selected Methods 1-4 to value your goods
@@ -606,7 +606,7 @@ whyComputedValue.bulletPoint.4 = Method 4 (deductive method)
 whyComputedValue.paragraph.2 = Explain why you believe Methods 1-4 are not suitable to work out the customs value of your goods.
 whyComputedValue.checkYourAnswersLabel = Reason for not selecting Methods 1-4 to value your goods
 whyComputedValue.error.required = Enter an explanation about why you have not selected methods 1 to 4 to value your goods
-whyComputedValue.error.length = Maximum allowed characters is 8168
+whyComputedValue.error.length = Explanation of why you have not used Methods 1 to 4 must be 8,167 characters or less
 whyComputedValue.change.hidden = your reason for not selecting Methods 1-4 to value the goods
 
 haveYouUsedMethodOneInPast.title = Provide evidence of a Method 1 declaration
@@ -632,7 +632,7 @@ whyTransactionValueOfSimilarGoods.paragraph.2 = Explain why you believe Methods 
 whyTransactionValueOfSimilarGoods.bulletPoint.1 = Method 1 (transaction value of imported goods)
 whyTransactionValueOfSimilarGoods.bulletPoint.2 = Method 2 (transaction value of identical goods)
 whyTransactionValueOfSimilarGoods.error.required = Enter an explanation about why you have not selected Method 1 or 2 to value your goods
-whyTransactionValueOfSimilarGoods.error.length = Maximum allowed characters is 8168
+whyTransactionValueOfSimilarGoods.error.length = Explanation of why you have not selected Methods 1 or 2 must be 8,167 or less
 whyTransactionValueOfSimilarGoods.checkYourAnswersLabel = Reason for not selecting Methods 1 or 2 to value your goods
 whyTransactionValueOfSimilarGoods.change.hidden = your reason for not selecting Methods 1-2 to value the goods
 
@@ -645,7 +645,7 @@ whyIdenticalGoods.bulletPoint.1 = Method 1 (transaction value of imported goods)
 whyIdenticalGoods.paragraph.2 = Explain why you believe Method 1 is not suitable to work out the customs value of your goods.
 whyIdenticalGoods.checkYourAnswersLabel = Reason for not selecting Method 1 to value your goods
 whyIdenticalGoods.error.required = Enter an explanation of why you have not selected Method 1 to value your goods
-whyIdenticalGoods.error.length = Maximum allowed characters is 8168
+whyIdenticalGoods.error.length = Explanation of wht you have not selected Method 1 must be 8,167 characters or less
 whyIdenticalGoods.change.hidden = your reason for not selecting Method 1 to value the goods
 
 explainHowPartiesAreRelated.title = Describe how the parties are related
@@ -656,7 +656,7 @@ explainHowPartiesAreRelated.para.1 = We can only accept the price paid or payabl
 explainHowPartiesAreRelated.para.2 = Giving a detailed description of the relationship helps us process your application as quickly as possible.
 explainHowPartiesAreRelated.error.required = Enter a description of how the parties are related
 explainHowPartiesAreRelated.checkYourAnswersLabel = Description of how the parties are related
-explainHowPartiesAreRelated.error.length = Maximum allowed characters is 8168
+explainHowPartiesAreRelated.error.length = Description of how the parties are related must be 8,167 characters or less
 explainHowPartiesAreRelated.change.hidden = your description of how the parties are related
 explainHowPartiesAreRelated.question = Can you describe how the parties are related?
 
@@ -695,7 +695,7 @@ describeTheRestrictions.label = Describe any restrictions on the use or resale o
 describeTheRestrictions.caption = About the goods
 describeTheRestrictions.checkYourAnswersLabel = Description of restrictions
 describeTheRestrictions.error.required = Enter a description of the restrictions involved
-describeTheRestrictions.error.length = Maximum allowed characters is 8168
+describeTheRestrictions.error.length = Description of the restrictions must be 8,167 characters or less
 describeTheRestrictions.paragraph.1 = Giving a detailed description of any restrictions helps us process your application as quickly as possible
 describeTheRestrictions.change.hidden = your description of the restrictions on the use/resale of the goods
 
@@ -717,7 +717,7 @@ describeTheConditions.label = Describe the conditions or circumstances which can
 describeTheConditions.caption = About the goods
 describeTheConditions.checkYourAnswersLabel = Description of conditions/circumstances
 describeTheConditions.error.required = Enter a description of any conditions or circumstances that cannot be calculated
-describeTheConditions.error.length = Maximum allowed characters is 8168
+describeTheConditions.error.length = Description of the circumstances must be 8,167 characters or less
 describeTheConditions.paragraph.1 = Giving a detailed description of any conditions or circumstances helps us process your application as quickly as possible.
 describeTheConditions.change.hidden = your description of the conditions or circumstances which cannot be calculated
 
@@ -731,7 +731,7 @@ describeTheIdenticalGoods.bulletPoint.2 = exported to the UK at or about the sam
 describeTheIdenticalGoods.bulletPoint.3 = the same in all respects including physical characteristics, quality and reputation — minor differences in appearance do not matter
 describeTheIdenticalGoods.checkYourAnswersLabel = Description of identical goods
 describeTheIdenticalGoods.error.required = Enter a description of the identical goods
-describeTheIdenticalGoods.error.length = Maximum allowed characters is 8168
+describeTheIdenticalGoods.error.length = Description of identical goods must be 8,167 characters or less
 describeTheIdenticalGoods.change.hidden = your description of the identical goods
 
 
@@ -744,7 +744,7 @@ explainYourGoodsComparingToIdenticalGoods.bulletPoint.1 = you do not think Metho
 explainYourGoodsComparingToIdenticalGoods.bulletPoint.2 = you do not have any further information about the identical goods
 explainYourGoodsComparingToIdenticalGoods.checkYourAnswersLabel = Explanation of how you are using another producer’s identical goods for comparison
 explainYourGoodsComparingToIdenticalGoods.error.required = Enter an explanation about how you are comparing your goods to identical goods imported by another buyer or seller in the past 90 days
-explainYourGoodsComparingToIdenticalGoods.error.length = Maximum allowed characters is 8168
+explainYourGoodsComparingToIdenticalGoods.error.length = Explanation must be 8,167 characters or less
 explainYourGoodsComparingToIdenticalGoods.change.hidden = your explanation of how you are using another producer’s identical goods for comparison
 
 willYouCompareGoodsToIdenticalGoods.title = Will you be comparing your goods to identical goods imported by another buyer or seller in the past 90-days?
@@ -762,7 +762,7 @@ describeTheLegalChallenges.caption = About the goods
 describeTheLegalChallenges.para = Giving a detailed description of legal challenges helps us process your application as quickly as possible.
 describeTheLegalChallenges.checkYourAnswersLabel = Description of legal challenges
 describeTheLegalChallenges.error.required = Enter a description of the legal challenges relating to the goods
-describeTheLegalChallenges.error.length = Maximum allowed characters is 8168
+describeTheLegalChallenges.error.length = Description of legal challenges relating to the goods must be 8,167 characters or less
 describeTheLegalChallenges.change.hidden = your description of the legal challenges
 
 
@@ -825,7 +825,7 @@ explainWhyYouChoseMethodFour.paragraph.2 = You can only use Method 4 if the good
 explainWhyYouChoseMethodFour.paragraph.3 = ‘Unrelated’ means there isn’t an existing relationship or common interest between two companies.
 explainWhyYouChoseMethodFour.checkYourAnswersLabel = Reason for selecting Method 4 to value your goods
 explainWhyYouChoseMethodFour.error.required = Enter an explanation about why you have selected Method 4 to value your goods
-explainWhyYouChoseMethodFour.error.length = Maximum allowed characters is 8168
+explainWhyYouChoseMethodFour.error.length = xplanation of why you have used Method 4 must be 8,167 characters or less
 explainWhyYouChoseMethodFour.change.hidden = your reason for selecting Method 4 to value the goods
 
 explainWhyYouHaveNotSelectedMethodOneToThree.title = Explain why you have not selected Methods 1-3 to value your goods
@@ -839,7 +839,7 @@ explainWhyYouHaveNotSelectedMethodOneToThree.bulletPoint.3 = Method 3 (transacti
 explainWhyYouHaveNotSelectedMethodOneToThree.paragraph.2 = Explain why you believe Methods 1-3 are not suitable to work out the customs value of your goods.
 explainWhyYouHaveNotSelectedMethodOneToThree.checkYourAnswersLabel = Reason for not selecting Methods 1-3 to value your goods
 explainWhyYouHaveNotSelectedMethodOneToThree.error.required = Enter an explanation about why you have not selected methods 1 to 3 to value your goods
-explainWhyYouHaveNotSelectedMethodOneToThree.error.length = Maximum allowed characters is 8168
+explainWhyYouHaveNotSelectedMethodOneToThree.error.length = Explanation of why you have not used Methods 1 to 3 must be 8,167 characters or less
 explainWhyYouHaveNotSelectedMethodOneToThree.change.hidden = your reason for not selecting Methods 1-3 to value the goods
 
 adaptMethod.title = Which method would you like to adapt?
@@ -862,7 +862,7 @@ explainWhyYouHaveNotSelectedMethodOneToFive.label = Explain why you have not sel
 explainWhyYouHaveNotSelectedMethodOneToFive.caption = About the goods
 explainWhyYouHaveNotSelectedMethodOneToFive.checkYourAnswersLabel = Reason for not selecting Methods 1-5 to value your goods
 explainWhyYouHaveNotSelectedMethodOneToFive.error.required = Enter an explanation about why you have not selected methods 1 to 5 to value your goods
-explainWhyYouHaveNotSelectedMethodOneToFive.error.length = Maximum allowed characters is 8168
+explainWhyYouHaveNotSelectedMethodOneToFive.error.length = Explanation of why you have not used Methods 1 to 5 must be 8,167 characters or less
 explainWhyYouHaveNotSelectedMethodOneToFive.paragraph.1 = Method 6 is the ‘fall-back’ method to use when you are unable to use any of the other methods. Before you try Method 6 you must first have used:
 explainWhyYouHaveNotSelectedMethodOneToFive.bulletPoint.1 = Method 1 (transaction value of imported goods)
 explainWhyYouHaveNotSelectedMethodOneToFive.bulletPoint.2 = Method 2 (transaction value of identical goods)
@@ -878,7 +878,7 @@ explainHowYouWillUseMethodSix.label = Explain how you have used Method 6 to valu
 explainHowYouWillUseMethodSix.caption = About the goods
 explainHowYouWillUseMethodSix.checkYourAnswersLabel = Explanation of how you have used Method 6 to value your goods
 explainHowYouWillUseMethodSix.error.required = Enter an explanation about how you have used Method 6 to value your goods
-explainHowYouWillUseMethodSix.error.length = Maximum allowed characters is 8168
+explainHowYouWillUseMethodSix.error.length = Explanation of why you have used Method 6 must be 8,167 characters or less
 explainHowYouWillUseMethodSix.paragraph.1 = Method 6 (fall-back method) is the final valuation method you can try.
 explainHowYouWillUseMethodSix.paragraph.2 = Tell us how you plan to use Method 6. You should also let us know if you want to adapt another method for your circumstances.
 explainHowYouWillUseMethodSix.change.hidden = your explanation of how you have used Method 6 to value the goods
@@ -893,7 +893,7 @@ describeTheSimilarGoods.bulletPoint.2 = can carry out the same tasks
 describeTheSimilarGoods.bulletPoint.3 = are commercially interchangeable
 describeTheSimilarGoods.checkYourAnswersLabel = Description of similar goods
 describeTheSimilarGoods.error.required = Enter a description of the similar goods
-describeTheSimilarGoods.error.length = Maximum allowed characters is 8168
+describeTheSimilarGoods.error.length = Description of similar goods must be 8,167 characters or less
 describeTheSimilarGoods.change.hidden = your description of the similar goods
 
 haveYouUsedMethodOneForSimilarGoodsInPast.title = Provide evidence of a Method 1 declaration
@@ -1065,7 +1065,7 @@ tellUsAboutYourRuling.bulletPoint.4 = the expiry date for the ruling
 
 tellUsAboutYourRuling.error.required = Tell us about the ruling
 
-textCount.tooLong = Description of rulings must be 8000 characters or less
+textCount.tooLong = Description of rulings must be 8,000 characters or less
 
 aboutSimilarGoods.para.1 = These can be:
 aboutSimilarGoods.para.2 = Include as much information as possible, such as:


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non-breaking change
- [ x] Cosmetic change

### Description
[Jira link](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-427)

Replace textareas with character count components, which provides feedback on the number of characters the user has remaining, or how many they are over the limit.

Because users are unlikely to come close to the limit, a threshold of 75% has been added (meaning the character count doesn't display until the user has entered 75% of the allowed character count).  This is advised by the GOV.UK design system.