### PR TITLE
ARSSTB-564

### DIFF
--- a/app/controllers/common/FileUploadHelper.scala
+++ b/app/controllers/common/FileUploadHelper.scala
@@ -268,7 +268,14 @@ case class FileUploadHelper @Inject() (
       case "EntityTooLarge"  =>
         Messages(s"fileUpload.error.entitytoolarge", maxFileSize)
       case "EntityTooSmall"  =>
-        Messages("fileUpload.error.entitytoosmall")
+        /*
+         * As of writing this comment, Upscan has an issue in detecting whether a file has been selected.
+         * If the minimum file size is 0, the user will see the error message associated with the "Rejected" case
+         * rather than the "InvalidArgument" case they should expect when not selecting a file.
+         * The fix is to set a positive minimum file size and display the expected error message via this case.
+         * See the application.conf for the minimum file size.
+         */
+        Messages("fileUpload.error.invalidargument")
       case "Rejected"        =>
         Messages("fileUpload.error.rejected")
       case "Quarantine"      =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -180,7 +180,7 @@ tracking-consent-frontend {
 
 upscan {
   callbackBaseUrl = "http://localhost:12600"
-  minFileSize = 0
+  minFileSize = "1b"
   maxFileSize = "5000000b"
   maxFiles    = 5
 }

--- a/test/controllers/FileUploadHelperSpec.scala
+++ b/test/controllers/FileUploadHelperSpec.scala
@@ -132,7 +132,7 @@ class FileUploadHelperSpec extends SpecBase with MockitoSugar with BeforeAndAfte
   ): String =
     if (isLetterOfAuthority) {
       controllers.routes.UploadLetterOfAuthorityController
-        .onPageLoad(mode, draftId, errorCode, key, false)
+        .onPageLoad(mode, draftId, errorCode, key, redirectedFromChangeButton = false)
         .url
     } else {
       controllers.routes.UploadSupportingDocumentsController
@@ -650,7 +650,7 @@ class FileUploadHelperSpec extends SpecBase with MockitoSugar with BeforeAndAfte
         "EntityTooSmall",
         UploadedFile.FailureReason.EntityTooSmall,
         (messagesProvider: MessagesProvider) =>
-          Messages.apply("fileUpload.error.entitytoosmall")(messagesProvider)
+          Messages.apply("fileUpload.error.invalidargument")(messagesProvider)
       ),
       (
         "EntityTooLarge",


### PR DESCRIPTION
### Type of change
- [x] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [No files selected error handling is not accessible [WCAG A]](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-564)

Introduce a minimum file size so that upscan can catch this error when no file has been chosen by the user to upload.

Note that this is not testable locally since the issue is not visible in the local environment (due to the fact that we are interacting with upscan-stub locally).