### PR TITLE
Arsstb 598

### DIFF
--- a/app/controllers/UploadAnotherSupportingDocumentController.scala
+++ b/app/controllers/UploadAnotherSupportingDocumentController.scala
@@ -27,7 +27,6 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import controllers.actions._
 import forms.UploadAnotherSupportingDocumentFormProvider
 import models._
-import models.requests.DataRequest
 import navigation.Navigator
 import pages.{UploadAnotherSupportingDocumentPage, UploadLetterOfAuthorityPage}
 import queries.AllDocuments
@@ -51,7 +50,7 @@ class UploadAnotherSupportingDocumentController @Inject() (
       implicit request =>
         val attachments = AllDocuments.get().getOrElse(List.empty)
         val form        = formProvider(attachments)
-        val loaFileName = getLetterOfAuthorityFileName(request)
+        val loaFileName = getLetterOfAuthorityFileName(request.userAnswers)
         Ok(view(attachments, form, mode, draftId, loaFileName))
     }
 
@@ -70,7 +69,7 @@ class UploadAnotherSupportingDocumentController @Inject() (
                     formWithErrors,
                     mode,
                     draftId,
-                    getLetterOfAuthorityFileName(request)
+                    getLetterOfAuthorityFileName(request.userAnswers)
                   )
                 )
               ),
@@ -83,8 +82,8 @@ class UploadAnotherSupportingDocumentController @Inject() (
           )
     }
 
-  private def getLetterOfAuthorityFileName(request: DataRequest[AnyContent]) = {
-    val loaFile     = request.userAnswers.get(UploadLetterOfAuthorityPage)
+  private def getLetterOfAuthorityFileName(userAnswers: UserAnswers): Option[String] = {
+    val loaFile     = userAnswers.get(UploadLetterOfAuthorityPage)
     val loaFileName = loaFile match {
       case Some(file) => file.fileName
       case None       => None


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Bug - Letter of authority disappears on uploaded supporting docs page](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-598)

Ensure that the letter of authority is shown in the view when the user selects Save and continue without selecting a radio button.

### Attachments or Screenshots
![Fix LOA displayed with error](https://github.com/hmrc/advance-valuation-rulings-frontend/assets/132440545/08182144-576a-4ebb-b9d2-a2adadb45722)
