### PR TITLE
ARSSTB-495 Update button links to use lib components

### DIFF
--- a/app/views/components/SaveButtons.scala.html
+++ b/app/views/components/SaveButtons.scala.html
@@ -23,9 +23,13 @@
             ButtonViewModel(messages(submitButtonMessageKey))
         )
 
-        <a href="@routes.DraftHasBeenSavedController.onPageLoad(draftId).url" role="button" class="govuk-button govuk-button--secondary">
-            @messages("site.saveAsDraft")
-        </a>
+        @govukButton(Button(
+            classes = "govuk-button--secondary",
+            content = Text(messages("site.saveAsDraft")),
+            href = Some(routes.DraftHasBeenSavedController.onPageLoad(draftId).url)
+            )
+        )
+
     </div>
 
     

--- a/app/views/components/SaveButtonsWithTarget.scala.html
+++ b/app/views/components/SaveButtonsWithTarget.scala.html
@@ -20,13 +20,18 @@
 
     <div class="govuk-button-group">
 
-        <a href="@target" role="button" class="govuk-button">
-            @messages(submitButtonMessageKey)
-        </a>
+        @govukButton(Button(
+            content = Text(messages(submitButtonMessageKey)),
+            href = Some(target.toString)
+            )
+        )
 
-        <a href="@routes.DraftHasBeenSavedController.onPageLoad(draftId).url" role="button" class="govuk-button govuk-button--secondary">
-            @messages("site.saveAsDraft")
-        </a>
+        @govukButton(Button(
+            classes = "govuk-button--secondary",
+            content = Text(messages("site.saveAsDraft")),
+            href = Some(routes.DraftHasBeenSavedController.onPageLoad(draftId).url)
+            )
+        )
     </div>
 
     


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non-breaking change
- [ x] Cosmetic change

### Description
Jira link: ["Save as draft" uses "role - button" but is missing data-module from the library](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-495)

Some buttons for "Save and continue" and "Save as draft" were links styled to look like buttons.
To act as buttons they need to have js event handlers applied (so users can use the spacebar to action them, just like real buttons). The best way to do this is to use the lib button component which both applies the styles to the links but also all the aria role and event handlers.
(You can pass an `href` into a Button component and it will generate a link rather than a button element)
