### PR TITLE
ARSSTB-589 Save as draft on text fields fix

### DIFF
--- a/app/controllers/AgentCompanyDetailsController.scala
+++ b/app/controllers/AgentCompanyDetailsController.scala
@@ -62,7 +62,12 @@ class AgentCompanyDetailsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/ApplicationContactDetailsController.scala
+++ b/app/controllers/ApplicationContactDetailsController.scala
@@ -66,7 +66,12 @@ class ApplicationContactDetailsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/BusinessContactDetailsController.scala
+++ b/app/controllers/BusinessContactDetailsController.scala
@@ -72,8 +72,12 @@ class BusinessContactDetailsController @Inject() (
           .bindFromRequest()
           .fold(
             formWithErrors =>
-              Future
-                .successful(BadRequest(view(formWithErrors, mode, draftId, includeCompanyName()))),
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future
+                  .successful(BadRequest(view(formWithErrors, mode, draftId, includeCompanyName())))
+              },
             value =>
               for {
                 updatedAnswers <- BusinessContactDetailsPage.set(value)

--- a/app/controllers/CommodityCodeController.scala
+++ b/app/controllers/CommodityCodeController.scala
@@ -62,7 +62,12 @@ class CommodityCodeController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- Future.fromTry(request.userAnswers.set(CommodityCodePage, value))

--- a/app/controllers/ConfidentialInformationController.scala
+++ b/app/controllers/ConfidentialInformationController.scala
@@ -61,7 +61,12 @@ class ConfidentialInformationController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- ConfidentialInformationPage.set(value)

--- a/app/controllers/DescribeTheConditionsController.scala
+++ b/app/controllers/DescribeTheConditionsController.scala
@@ -62,7 +62,12 @@ class DescribeTheConditionsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- DescribeTheConditionsPage.set(value)

--- a/app/controllers/DescribeTheIdenticalGoodsController.scala
+++ b/app/controllers/DescribeTheIdenticalGoodsController.scala
@@ -62,7 +62,12 @@ class DescribeTheIdenticalGoodsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/DescribeTheLegalChallengesController.scala
+++ b/app/controllers/DescribeTheLegalChallengesController.scala
@@ -62,7 +62,12 @@ class DescribeTheLegalChallengesController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/DescribeTheRestrictionsController.scala
+++ b/app/controllers/DescribeTheRestrictionsController.scala
@@ -61,7 +61,12 @@ class DescribeTheRestrictionsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/DescribeTheSimilarGoodsController.scala
+++ b/app/controllers/DescribeTheSimilarGoodsController.scala
@@ -62,7 +62,12 @@ class DescribeTheSimilarGoodsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/DescriptionOfGoodsController.scala
+++ b/app/controllers/DescriptionOfGoodsController.scala
@@ -62,7 +62,12 @@ class DescriptionOfGoodsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/ExplainHowPartiesAreRelatedController.scala
+++ b/app/controllers/ExplainHowPartiesAreRelatedController.scala
@@ -62,7 +62,12 @@ class ExplainHowPartiesAreRelatedController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- ExplainHowPartiesAreRelatedPage.set(value)

--- a/app/controllers/ExplainHowYouWillUseMethodSixController.scala
+++ b/app/controllers/ExplainHowYouWillUseMethodSixController.scala
@@ -62,7 +62,12 @@ class ExplainHowYouWillUseMethodSixController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/ExplainReasonComputedValueController.scala
+++ b/app/controllers/ExplainReasonComputedValueController.scala
@@ -62,7 +62,12 @@ class ExplainReasonComputedValueController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/ExplainWhyYouChoseMethodFourController.scala
+++ b/app/controllers/ExplainWhyYouChoseMethodFourController.scala
@@ -62,7 +62,12 @@ class ExplainWhyYouChoseMethodFourController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/ExplainWhyYouHaveNotSelectedMethodOneToFiveController.scala
+++ b/app/controllers/ExplainWhyYouHaveNotSelectedMethodOneToFiveController.scala
@@ -62,7 +62,12 @@ class ExplainWhyYouHaveNotSelectedMethodOneToFiveController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <-

--- a/app/controllers/ExplainWhyYouHaveNotSelectedMethodOneToThreeController.scala
+++ b/app/controllers/ExplainWhyYouHaveNotSelectedMethodOneToThreeController.scala
@@ -62,7 +62,12 @@ class ExplainWhyYouHaveNotSelectedMethodOneToThreeController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- ExplainWhyYouHaveNotSelectedMethodOneToThreePage.set(value)

--- a/app/controllers/ProvideTraderEoriController.scala
+++ b/app/controllers/ProvideTraderEoriController.scala
@@ -77,7 +77,11 @@ class ProvideTraderEoriController @Inject() (
           .bindFromRequest()
           .fold(
             formWithErrors =>
-              Future.successful(BadRequest(provideTraderEoriView(formWithErrors, mode, draftId))),
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(provideTraderEoriView(formWithErrors, mode, draftId)))
+              },
             eoriInput =>
               request.userAnswers.set(ProvideTraderEoriPage, eoriInput.toUpperCase()) match {
                 case Success(eoriAnswers) =>

--- a/app/controllers/WhyComputedValueController.scala
+++ b/app/controllers/WhyComputedValueController.scala
@@ -62,7 +62,12 @@ class WhyComputedValueController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- WhyComputedValuePage.set(value)

--- a/app/controllers/WhyIdenticalGoodsController.scala
+++ b/app/controllers/WhyIdenticalGoodsController.scala
@@ -62,7 +62,12 @@ class WhyIdenticalGoodsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- WhyIdenticalGoodsPage.set(value)

--- a/app/controllers/WhyTransactionValueOfSimilarGoodsController.scala
+++ b/app/controllers/WhyTransactionValueOfSimilarGoodsController.scala
@@ -62,7 +62,12 @@ class WhyTransactionValueOfSimilarGoodsController @Inject() (
         form
           .bindFromRequest()
           .fold(
-            formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, draftId))),
+            formWithErrors =>
+              if (saveDraft) {
+                Future.successful(Redirect(routes.DraftHasBeenSavedController.onPageLoad(draftId)))
+              } else {
+                Future.successful(BadRequest(view(formWithErrors, mode, draftId)))
+              },
             value =>
               for {
                 updatedAnswers <- WhyTransactionValueOfSimilarGoodsPage.set(value)

--- a/app/views/AboutSimilarGoodsView.scala.html
+++ b/app/views/AboutSimilarGoodsView.scala.html
@@ -35,7 +35,7 @@
 )
 
 @(form: Form[_], mode: Mode, draftId: DraftId)(implicit request: Request[_], messages: Messages)
-@onSubmitAction(saveDraft: Boolean = true) = @{routes.AboutSimilarGoodsController.onSubmit(NormalMode, draftId)
+@onSubmitAction(saveDraft: Boolean = true) = @{routes.AboutSimilarGoodsController.onSubmit(NormalMode, draftId, saveDraft)
 }
 
 @content = {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -244,9 +244,9 @@ GET        /:draftId/change-aware-of-previous-ruling          controllers.AwareO
 POST       /:draftId/change-aware-of-previous-ruling          controllers.AwareOfRulingController.onSubmit(mode: Mode = CheckMode, draftId: DraftId)
 
 GET        /:draftId/about-similar-goods             controllers.AboutSimilarGoodsController.onPageLoad(mode: Mode = NormalMode, draftId: DraftId)
-POST       /:draftId/about-similar-goods             controllers.AboutSimilarGoodsController.onSubmit(mode: Mode = NormalMode, draftId: DraftId)
+POST       /:draftId/about-similar-goods             controllers.AboutSimilarGoodsController.onSubmit(mode: Mode = NormalMode, draftId: DraftId, saveDraft: Boolean)
 GET        /:draftId/change-about-similar-goods      controllers.AboutSimilarGoodsController.onPageLoad(mode: Mode = CheckMode, draftId: DraftId)
-POST       /:draftId/change-about-similar-goods      controllers.AboutSimilarGoodsController.onSubmit(mode: Mode = CheckMode, draftId: DraftId)
+POST       /:draftId/change-about-similar-goods      controllers.AboutSimilarGoodsController.onSubmit(mode: Mode = CheckMode, draftId: DraftId, saveDraft: Boolean)
 
 
 GET        /application/:id                            controllers.ViewApplicationController.onPageLoad(id: String)

--- a/test/controllers/AboutSimilarGoodsControllerSpec.scala
+++ b/test/controllers/AboutSimilarGoodsControllerSpec.scala
@@ -36,7 +36,8 @@ import views.html.{AboutSimilarGoodsView, TellUsAboutYourRulingView}
 class AboutSimilarGoodsControllerSpec extends SpecBase with MockitoSugar {
 
   lazy val getRoute  = routes.AboutSimilarGoodsController.onPageLoad(NormalMode, draftId).url
-  lazy val postRoute = routes.AboutSimilarGoodsController.onSubmit(NormalMode, draftId).url
+  lazy val postRoute =
+    routes.AboutSimilarGoodsController.onSubmit(NormalMode, draftId, saveDraft = false).url
 
   val formProvider = new AboutSimilarGoodsFormProvider()
   val form         = formProvider()


### PR DESCRIPTION
Desired behaviour implemented:

On text fields ----
If a user inputs invalid or no data and clicks save as draft - Discard their input (if any) and save as draft.
If a user inputs valid data and clicks save as draft - Keep their data and save as draft.
If a user just clicks save and continue - continue the journey with saved data.