### PR TITLE
ARSSTB-681 Updated list markup for docs

### DIFF
--- a/app/views/UploadAnotherSupportingDocumentView.scala.html
+++ b/app/views/UploadAnotherSupportingDocumentView.scala.html
@@ -92,34 +92,29 @@
 
         @if(letterOfAuthorityFileName.isDefined) {
             @if(numOfDocs == 3) {
-                <br/>
                 <p class="govuk-body">@messages("uploadAnotherSupportingDocument.remaining.one")</p>
             } else if (numOfDocs != 4) {
-                <br/>
                 <p class="govuk-body">@messages("uploadAnotherSupportingDocument.remaining", 4 - numOfDocs)</p>
             }
         } else {
             @if(numOfDocs == 4) {
-                <br/>
                 <p class="govuk-body">@messages("uploadAnotherSupportingDocument.remaining.one")</p>
             } else if (numOfDocs != 5) {
-                <br/>
                 <p class="govuk-body">@messages("uploadAnotherSupportingDocument.remaining", 5 - numOfDocs)</p>
             }
         }
 
-        <br/>
 
         @subheading(messages("uploadAnotherSupportingDocument.uploadedDocuments"))
 
         <div class="govuk-form-group">
-            <dl class="govuk-summary-list">
+            <dl class="govuk-summary-list hmrc-list-with-actions">
             @attachments.zipWithIndex.map { case (attachment, index) =>
                 <div class="govuk-summary-list__row">
-                    <dd class="govuk-summary-list__value">
+                    <dt class="govuk-summary-list__key hmrc-summary-list__key govuk-!-font-weight-regular">
                         @attachment.file.fileName.getOrElse("")
-                    </dd>
-                    <dd>
+                    </dt>
+                    <dd class="govuk-summary-list__value">
                         @if(attachment.isThisFileConfidential.contains(true)) {
                             @messages("uploadAnotherSupportingDocument.keepConfidential")
                         }
@@ -135,17 +130,16 @@
             </dl>
         </div>
 
+
         @letterOfAuthorityFileName.map { filename =>
             @subheading(messages("uploadAnotherSupportingDocument.letterOfAuthority"))
 
-            <div class="govuk-form-group">
-                <dl class="govuk-summary-list">
-                    <div class="govuk-summary-list__row">
-                        <dd class="govuk-summary-list__value">
-                            @filename
-                        </dd>
-                    </div>
-                </dl>
+            <div class="govuk-form-group">                
+                <div class="govuk-body">
+                    @filename
+                </div>
+                <hr class="govuk-section-break govuk-section-break--visible" role="presentation">
+
             </div>
         }
 


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non-breaking change
- [ x] Cosmetic change

### Description
Jira link: [Accessibility Jenkins job failure](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-681)

Fixes markup for showing supporting docs and letter of authority.
Corrected definition list markup for supporting docs.
Updated letter of auth to remove list markup (as only ever going to be one).

### Attachments or Screenshots

<img width="740" alt="Screenshot 2023-10-27 at 12 15 04" src="https://github.com/hmrc/advance-valuation-rulings-frontend/assets/14074579/b9937f77-0fa8-4b2b-82b1-a38de2b191d0">
