### PR TITLE
Revert "ARSSTB-539"

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,11 +17,11 @@ include "frontend.conf"
 appName="advance-valuation-rulings-frontend"
 
 play.http.router = prod.Routes
-
+play.filters.headers.contentSecurityPolicy = "script-src 'unsafe-inline' 'self' https://www.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com; font-src 'self' data: https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com; img-src 'self' https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com data:; style-src 'self' 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com; frame-src 'self' https://www.googletagmanager.com"
 play.http.errorHandler = "handlers.ErrorHandler"
 
 play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
-play.filters.enabled += "play.filters.csp.CSPFilter"
+
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
-play.filters.disabled += "play.filters.csp.CSPFilter"
 
 play.http.secret.key = "some_secret"
 


### PR DESCRIPTION
Reverts hmrc/advance-valuation-rulings-frontend#551

Turns out that something to do with this change breaks the back-links functionality.