### PR TITLE
ARSSTB-539 added CSPNonce's and directives to repair back buttons

### DIFF
--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -44,8 +44,8 @@
 )(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
 
 @additionalScripts = {
-  <script src='@controllers.routes.Assets.versioned("javascripts/accessible-autocomplete.js")'></script>
-  <script src='@controllers.routes.Assets.versioned("javascripts/application.min.js")'></script>
+  <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("javascripts/accessible-autocomplete.js")'></script>
+  <script @CSPNonce.attr src='@controllers.routes.Assets.versioned("javascripts/application.min.js")'></script>
 }
 
 @headBlock = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,11 +17,10 @@ include "frontend.conf"
 appName="advance-valuation-rulings-frontend"
 
 play.http.router = prod.Routes
-play.filters.headers.contentSecurityPolicy = "script-src 'unsafe-inline' 'self' https://www.google-analytics.com https://www.googletagmanager.com https://tagmanager.google.com; font-src 'self' data: https://ssl.gstatic.com https://www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com; img-src 'self' https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com data:; style-src 'self' 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com; frame-src 'self' https://www.googletagmanager.com"
 play.http.errorHandler = "handlers.ErrorHandler"
 
 play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
-
+play.filters.enabled += "play.filters.csp.CSPFilter"
 
 play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "https://www.googletagmanager.com https://tagmanager.google.com localhost:12600"
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -23,6 +23,8 @@ play.http.errorHandler = "handlers.ErrorHandler"
 play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFilter"
 
 
+play.filters.csp.directives.script-src = ${play.filters.csp.nonce.pattern} "https://www.googletagmanager.com https://tagmanager.google.com localhost:12600"
+
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
+play.filters.disabled += "play.filters.csp.CSPFilter"
 
 play.http.secret.key = "some_secret"
 


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [play.filters.headers.contentSecurityPolicy should be removed from config as it is deprecated](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-539)

play.filters.headers.contentSecurityPolicy should be removed from config as it is deprecated

Added CSPNonce to script tags and adapted security directives to allow JS to run
