### PR TITLE
DDCE-4895: Ensure mongo is not used in unit tests

### DIFF
--- a/it/repositories/CounterRepositorySpec.scala
+++ b/it/repositories/CounterRepositorySpec.scala
@@ -1,10 +1,9 @@
 package repositories
 
-import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
-
 import com.codahale.metrics.SharedMetricRegistries
 import models.{CounterId, CounterWrapper}
 import org.mongodb.scala.model.{Filters, FindOneAndUpdateOptions, Updates}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import utils.BaseIntegrationSpec
 
 class CounterRepositorySpec extends BaseIntegrationSpec with DefaultPlayMongoRepositorySupport[CounterWrapper] {
@@ -15,8 +14,8 @@ class CounterRepositorySpec extends BaseIntegrationSpec with DefaultPlayMongoRep
     repository.seed.futureValue
   }
 
-  override protected def checkTtlIndex = false
-  override protected val repository    = new CounterRepository(mongoComponent)
+  override protected def checkTtlIndex: Boolean             = false
+  override protected val repository: CounterMongoRepository = new CounterMongoRepository(mongoComponent)
 
   "on startup" - {
 

--- a/it/resources/application.conf
+++ b/it/resources/application.conf
@@ -1,15 +1,6 @@
-mongodb.uri = "mongodb://localhost:27017/advance-valuation-rulings-frontend-integration"
-
 akka {
   log-dead-letters = 10
   log-dead-letters-during-shutdown = on
-}
-
-mongo-async-driver {
-  akka {
-
-    loglevel = ERROR
-  }
 }
 
 create-internal-auth-token-on-start = false

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -116,8 +116,11 @@ trait SpecBase
   val traderDetailsWithConfirmation: TraderDetailsWithConfirmation =
     TraderDetailsWithConfirmation(traderDetailsWithCountryCode)
 
+  def messagesApi(app: Application): MessagesApi =
+    app.injector.instanceOf[MessagesApi]
+
   def messages(app: Application): Messages =
-    app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
+    messagesApi(app).preferred(FakeRequest())
 
   val mockDraftIdRepo: CounterRepository =
     mock[CounterRepository]

--- a/test/controllers/callback/AttachmentsControllerSpec.scala
+++ b/test/controllers/callback/AttachmentsControllerSpec.scala
@@ -20,14 +20,12 @@ import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import base.SpecBase
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, when}
-import org.scalatest.OptionValues
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
+import play.api.Application
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.objectstore.client.play.PlayObjectStoreClient
@@ -36,11 +34,11 @@ import uk.gov.hmrc.objectstore.client.{Md5Hash, Object, ObjectMetadata, Path}
 import java.time.Instant
 import scala.concurrent.Future
 
-class AttachmentsControllerSpec extends AnyFreeSpec with Matchers with ScalaFutures with OptionValues {
+class AttachmentsControllerSpec extends AnyFreeSpec with SpecBase {
 
   val mockObjectStoreClient: PlayObjectStoreClient = mock(classOf[PlayObjectStoreClient])
 
-  private lazy val app = GuiceApplicationBuilder()
+  private lazy val app: Application = applicationBuilder()
     .overrides(
       bind[PlayObjectStoreClient].toInstance(mockObjectStoreClient)
     )

--- a/test/controllers/callback/UploadCallbackControllerSpec.scala
+++ b/test/controllers/callback/UploadCallbackControllerSpec.scala
@@ -16,16 +16,14 @@
 
 package controllers.callback
 
+import base.SpecBase
 import models.{Done, DraftId, UploadedFile}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar.{mock, verify, when}
-import org.scalatest.OptionValues
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
+import play.api.Application
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -34,11 +32,11 @@ import services.fileupload.FileService
 import java.time.Instant
 import scala.concurrent.Future
 
-class UploadCallbackControllerSpec extends AnyFreeSpec with Matchers with ScalaFutures with OptionValues {
+class UploadCallbackControllerSpec extends AnyFreeSpec with SpecBase {
 
-  private val mockFileService = mock[FileService]
+  private val mockFileService: FileService = mock[FileService]
 
-  private lazy val app = GuiceApplicationBuilder()
+  private lazy val app: Application = applicationBuilder()
     .overrides(
       bind[FileService].toInstance(mockFileService)
     )

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -14,12 +14,6 @@
 
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
 play.filters.disabled += "play.filters.csp.CSPFilter"
-
-mongo-async-driver {
-  akka {
-    log-dead-letters-during-shutdown = off
-    log-dead-letters = 0
-  }
-}
+play.modules.disabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 
 create-internal-auth-token-on-start = false

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -23,8 +23,8 @@ import models.requests._
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar._
+import play.api.Application
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import services.email.EmailService
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -32,22 +32,21 @@ import scala.concurrent.Future
 
 class SubmissionServiceSpec extends SpecBase {
 
-  private val mockBackendConnector   = mock[BackendConnector]
-  private val mockEmailService       = mock[EmailService]
-  private val mockUserAnswersService = mock[UserAnswersService]
+  private val mockBackendConnector: BackendConnector     = mock[BackendConnector]
+  private val mockEmailService: EmailService             = mock[EmailService]
+  private val mockUserAnswersService: UserAnswersService = mock[UserAnswersService]
 
-  private val app =
-    GuiceApplicationBuilder()
-      .overrides(
-        bind[BackendConnector].toInstance(mockBackendConnector),
-        bind[UserAnswersService].toInstance(mockUserAnswersService),
-        bind[EmailService].toInstance(mockEmailService)
-      )
-      .build()
+  private val app: Application = applicationBuilder()
+    .overrides(
+      bind[BackendConnector].toInstance(mockBackendConnector),
+      bind[UserAnswersService].toInstance(mockUserAnswersService),
+      bind[EmailService].toInstance(mockEmailService)
+    )
+    .build()
 
-  private val service = app.injector.instanceOf[SubmissionService]
+  private val service: SubmissionService = app.injector.instanceOf[SubmissionService]
 
-  private val applicationRequest = ApplicationRequest(
+  private val applicationRequest: ApplicationRequest = ApplicationRequest(
     draftId = draftId,
     trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(false)),
     agent = None,

--- a/test/services/fileupload/FileServiceSpec.scala
+++ b/test/services/fileupload/FileServiceSpec.scala
@@ -16,6 +16,7 @@
 
 package services.fileupload
 
+import base.SpecBase
 import connectors.UpscanConnector
 import models.upscan.{UpscanInitiateRequest, UpscanInitiateResponse}
 import models.{Done, DraftAttachment, DraftId, NormalMode, UploadedFile, UserAnswers}
@@ -23,11 +24,9 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar._
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues, TryValues}
-import pages.{QuestionPage, UploadSupportingDocumentPage}
+import pages.UploadSupportingDocumentPage
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import queries.AllDocuments
@@ -39,24 +38,18 @@ import uk.gov.hmrc.objectstore.client.{Md5Hash, ObjectSummaryWithMd5, Path}
 import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.Future
 
-class FileServiceSpec
-    extends AnyFreeSpec
-    with Matchers
-    with ScalaFutures
-    with OptionValues
-    with BeforeAndAfterEach
-    with TryValues {
+class FileServiceSpec extends AnyFreeSpec with SpecBase with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
     reset(mockUpscanConnector, mockUserAnswersService, mockObjectStoreClient)
   }
 
-  private val mockUpscanConnector    = mock[UpscanConnector]
-  private val mockUserAnswersService = mock[UserAnswersService]
-  private val mockObjectStoreClient  = mock[PlayObjectStoreClient]
+  private val mockUpscanConnector: UpscanConnector         = mock[UpscanConnector]
+  private val mockUserAnswersService: UserAnswersService   = mock[UserAnswersService]
+  private val mockObjectStoreClient: PlayObjectStoreClient = mock[PlayObjectStoreClient]
 
-  private lazy val app = GuiceApplicationBuilder()
+  private lazy val app: GuiceApplicationBuilder = applicationBuilder()
     .configure(
       "host"                                                              -> "host",
       "microservice.services.advance-valuation-rulings-frontend.protocol" -> "http",
@@ -71,15 +64,15 @@ class FileServiceSpec
       bind[PlayObjectStoreClient].toInstance(mockObjectStoreClient)
     )
 
-  private lazy val service = app.injector().instanceOf[FileService]
+  private lazy val service: FileService = app.injector().instanceOf[FileService]
 
-  private val redirectPath: String             = controllers.routes.UploadSupportingDocumentsController
+  private val redirectPath: String = controllers.routes.UploadSupportingDocumentsController
     .onPageLoad(NormalMode, DraftId(0), None, None)
     .url
-  private val page: QuestionPage[UploadedFile] = UploadSupportingDocumentPage
-  private implicit val hc: HeaderCarrier       = HeaderCarrier()
 
-  private val response = UpscanInitiateResponse(
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  private val response: UpscanInitiateResponse = UpscanInitiateResponse(
     reference = "reference",
     uploadRequest = UpscanInitiateResponse.UploadRequest(
       href = "foobar",

--- a/test/utils/MessagesSpec.scala
+++ b/test/utils/MessagesSpec.scala
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-import scala.reflect.ClassTag
-import scala.util.matching.Regex
-
-import play.api.i18n.MessagesApi
-import play.api.test.Helpers.baseApplicationBuilder.injector
+package utils
 
 import base.SpecBase
+import play.api.i18n.MessagesApi
+
+import scala.util.matching.Regex
 
 class MessagesSpec extends SpecBase {
 
-  def inject[T](implicit evidence: ClassTag[T]): T = injector().instanceOf[T]
-
-  implicit lazy val realMessagesApi: MessagesApi = inject[MessagesApi]
+  implicit lazy val realMessagesApi: MessagesApi = messagesApi(applicationBuilder().build())
 
   private lazy val defaultMessages: Map[String, String] = getExpectedMessages("default")
 


### PR DESCRIPTION
- Disable `PlayMongoModule` in unit tests so they can run without Mongo