### PR TITLE
DDCE-8832 AVR: Replace standalone H2 Caption

### DIFF
--- a/app/views/AboutSimilarGoodsView.scala.html
+++ b/app/views/AboutSimilarGoodsView.scala.html
@@ -28,8 +28,7 @@
     hmrcCharacterCount: HmrcCharacterCount,
     list: BulletList,
     paragraph: Paragraph,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -63,8 +62,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("caption.goods"))
-        @heading(messages("aboutSimilarGoods.heading"))
+        @captionedHeading(
+            caption = messages("caption.goods"),
+            heading = messages("aboutSimilarGoods.heading")
+        )
 
         @content
 

--- a/app/views/AdaptMethodView.scala.html
+++ b/app/views/AdaptMethodView.scala.html
@@ -24,6 +24,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -38,8 +39,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
         }
 
-        @caption(messages("adaptMethod.caption"))
-        @heading(messages("adaptMethod.heading"))
+        @captionedHeading(
+            caption = messages("adaptMethod.caption"),
+            heading = messages("adaptMethod.heading")
+        )
 
         @govukRadios(
             RadiosViewModel(

--- a/app/views/AgentCompanyDetailsView.scala.html
+++ b/app/views/AgentCompanyDetailsView.scala.html
@@ -28,6 +28,7 @@
     saveButton: SaveButton,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink
 
@@ -43,8 +44,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("agentCompanyDetails.caption"))
-        @heading(messages("agentCompanyDetails.heading"))
+        @captionedHeading(
+            caption = messages("agentCompanyDetails.caption"),
+            heading = messages("agentCompanyDetails.heading")
+        )
         @paragraph(content = Html(messages("agentCompanyDetails.paragraph")),"govuk-hint")
 
         @govukInput(

--- a/app/views/AgentForOrgCheckRegisteredDetailsView.scala.html
+++ b/app/views/AgentForOrgCheckRegisteredDetailsView.scala.html
@@ -23,6 +23,7 @@
     govukRadios: GovukRadios,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     headingH3: headingH3,
     paragraph: Paragraph,
     subheading: Subheading,
@@ -35,9 +36,15 @@
 
 @headingContent = {
                 @if(registeredDetails.consentToDisclosureOfPersonalData) {
-                    @heading(messages("checkRegisteredDetails.heading.agentOrg", registeredDetails.EORINo))
+                    @captionedHeading(
+                        caption = messages("checkRegisteredDetails.caption"),
+                        heading = messages("checkRegisteredDetails.heading.agentOrg", registeredDetails.EORINo)
+                    )
                 } else {
-                    @heading(messages("checkRegisteredDetails.private.heading", registeredDetails.EORINo))
+                    @captionedHeading(
+                        caption = messages("checkRegisteredDetails.caption"),
+                        heading = messages("checkRegisteredDetails.private.heading", registeredDetails.EORINo)
+                    )
                 }
 }
 
@@ -85,7 +92,6 @@
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value")))
         }
 
-        @caption(messages("checkRegisteredDetails.caption"))
         @headingContent
 
         @paraContent

--- a/app/views/AgentForOrgEORIBeUpToDateView.scala.html
+++ b/app/views/AgentForOrgEORIBeUpToDateView.scala.html
@@ -23,6 +23,7 @@
   formHelper: FormWithCSRF,
   caption: Caption,
   heading: Heading,
+    captionedHeading: CaptionedHeading,
   paragraph: Paragraph,
   link: Link,
   bulletList: BulletList,
@@ -50,9 +51,10 @@
 
 @layout(pageTitle = titleNoForm(messages("eoriBeUpToDate.title.org")), draftId = Some(draftId)) {
 
-    @caption(messages("eoriBeUpToDate.caption"))
-
-    @heading(messages("eoriBeUpToDate.heading.org"))
+    @captionedHeading(
+        caption = messages("eoriBeUpToDate.caption"),
+        heading = messages("eoriBeUpToDate.heading.org")
+    )
     @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.1.org")))
     @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.2.org")))
 

--- a/app/views/AgentForTraderPrivateEORIBeUpToDateView.scala.html
+++ b/app/views/AgentForTraderPrivateEORIBeUpToDateView.scala.html
@@ -23,6 +23,7 @@
   formHelper: FormWithCSRF,
   caption: Caption,
   heading: Heading,
+    captionedHeading: CaptionedHeading,
   paragraph: Paragraph,
   cancelApplicationLink: CancelApplicationLink,
   config: FrontendAppConfig
@@ -32,9 +33,10 @@
 
 @layout(pageTitle = titleNoForm(messages("eoriBeUpToDate.title.agentOnBehalfOfTrader.private")), draftId = Some(draftId)) {
 
-    @caption(messages("eoriBeUpToDate.caption"))
-
-    @heading(messages("eoriBeUpToDate.heading.agentOnBehalfOfTrader.private"))
+    @captionedHeading(
+        caption = messages("eoriBeUpToDate.caption"),
+        heading = messages("eoriBeUpToDate.heading.agentOnBehalfOfTrader.private")
+    )
     @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.1.agentOnBehalfOfTrader.private")))
     @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.2.agentOnBehalfOfTrader.private")))
     @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.3.agentOnBehalfOfTrader.private")))

--- a/app/views/ApplicationContactDetailsView.scala.html
+++ b/app/views/ApplicationContactDetailsView.scala.html
@@ -22,8 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
     saveButton: SaveButton
@@ -39,8 +38,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("applicationContactDetails.caption"))
-        @heading(messages("applicationContactDetails.heading"))
+        @captionedHeading(
+            caption = messages("applicationContactDetails.caption"),
+            heading = messages("applicationContactDetails.heading")
+        )
         @paragraph(content = Html(messages("applicationContactDetails.paragraph")),"govuk-hint")
 
         @govukInput(

--- a/app/views/AreThereRestrictionsOnTheGoodsView.scala.html
+++ b/app/views/AreThereRestrictionsOnTheGoodsView.scala.html
@@ -23,8 +23,7 @@
     govukRadios: GovukRadios,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     subheading: Subheading,
     saveButton: SaveButton,
@@ -41,8 +40,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("areThereRestrictionsOnTheGoods.caption"))
-        @heading(messages("areThereRestrictionsOnTheGoods.heading"))
+        @captionedHeading(
+            caption = messages("areThereRestrictionsOnTheGoods.caption"),
+            heading = messages("areThereRestrictionsOnTheGoods.heading")
+        )
 
         @paragraph(content = Html(messages("areThereRestrictionsOnTheGoods.paragraph.1")))
         @bulletList(Seq(

--- a/app/views/AwareOfRulingView.scala.html
+++ b/app/views/AwareOfRulingView.scala.html
@@ -24,8 +24,6 @@ layout: templates.Layout,
 formHelper: FormWithCSRF,
 govukErrorSummary: GovukErrorSummary,
 govukRadios: GovukRadios,
-caption: Caption,
-heading: Heading,
 headingH3: headingH3,
 subheading: Subheading,
 paragraph: Paragraph,
@@ -49,9 +47,12 @@ radios: YesNoRadios
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("caption.goods"))
-
-        @radios(messages("awareOfRuling.heading"), radiosContent, form)
+        @radios(
+            messages("awareOfRuling.heading"),
+            radiosContent,
+            form,
+            caption = Some(messages("caption.goods"))
+        )
 
         @saveButton(draftId)
     }

--- a/app/views/BusinessContactDetailsView.scala.html
+++ b/app/views/BusinessContactDetailsView.scala.html
@@ -24,6 +24,7 @@
     govukInput: GovukInput,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
     saveButton: SaveButton
@@ -39,8 +40,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("businessContactDetails.caption"))
-        @heading(messages("businessContactDetails.heading"))
+        @captionedHeading(
+            caption = messages("businessContactDetails.caption"),
+            heading = messages("businessContactDetails.heading")
+        )
 
         @if(includeCompanyName){
             @paragraph(content = Html(messages("businessContactDetails.paragraph.agentTrader")))

--- a/app/views/ChangeYourRoleImporterView.scala.html
+++ b/app/views/ChangeYourRoleImporterView.scala.html
@@ -23,6 +23,7 @@
     govukRadios: GovukRadios,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     legend: LegendH2,
     yesNoRadio: yesNoRadio,
     paragraph: Paragraph,
@@ -39,9 +40,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value")))
         }
 
-        @caption(messages("caption.applicant"))
-
-        @heading(messages("changeYourRoleImporter.heading"))
+        @captionedHeading(
+            caption = messages("caption.applicant"),
+            heading = messages("changeYourRoleImporter.heading")
+        )
 
         @paragraph(Html(messages("changeYourRoleImporter.p1")))
 

--- a/app/views/ChoosingMethodView.scala.html
+++ b/app/views/ChoosingMethodView.scala.html
@@ -24,8 +24,7 @@
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
     cancelApplicationLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     subheading: Subheading,
     paragraph: Paragraph,
     link: Link,
@@ -49,8 +48,10 @@
 
     @formHelper(action = routes.ChoosingMethodController.onSubmit(draftId), Symbol("autoComplete") -> "off") {
 
-        @caption(messages("choosingMethod.caption"))
-        @heading(messages("choosingMethod.heading"))
+        @captionedHeading(
+            caption = messages("choosingMethod.caption"),
+            heading = messages("choosingMethod.heading")
+        )
         @paragraph(Html(messages("choosingMethod.paragraph.1", overviewLink)))
         @paragraph(Html(messages("choosingMethod.para")))
 

--- a/app/views/CommodityCodeView.scala.html
+++ b/app/views/CommodityCodeView.scala.html
@@ -22,8 +22,6 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    caption: Caption,
-    heading: Heading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
     saveButton: SaveButton
@@ -52,12 +50,14 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("commodityCode.caption"))
-
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("commodityCode.heading")).asPageHeading(),
+                label = LabelViewModel(
+                    HtmlContent(
+                        s"""<span class="govuk-caption-xl"><span class="govuk-visually-hidden">${messages("caption.prefix")} </span>${messages("commodityCode.caption")}</span>${messages("commodityCode.heading")}"""
+                    )
+                ).asPageHeading(),
                 )
                 .withWidth(Full)
                 .withHint(
@@ -70,4 +70,3 @@
 
     @cancelApplicationLink(draftId)
 }
-

--- a/app/views/ConfidentialInformationView.scala.html
+++ b/app/views/ConfidentialInformationView.scala.html
@@ -25,6 +25,7 @@
     cancelApplicationLink: CancelApplicationLink,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     govukInsetText: GovukInsetText,
     saveButton: SaveButton
@@ -50,9 +51,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("confidentialInformation.caption"))
-
-        @heading(messages("confidentialInformation.heading"))
+        @captionedHeading(
+            caption = messages("confidentialInformation.caption"),
+            heading = messages("confidentialInformation.heading")
+        )
 
         @paraContent
 

--- a/app/views/DescribeTheConditionsView.scala.html
+++ b/app/views/DescribeTheConditionsView.scala.html
@@ -23,8 +23,6 @@
     hmrcCharacterCount: HmrcCharacterCount,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
     paragraph: Paragraph,
     saveButton: SaveButton
 )
@@ -41,12 +39,14 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("describeTheConditions.caption"))
-
         @hmrcCharacterCount(
             CharacterCountViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("describeTheConditions.heading")).asPageHeading()
+                label = LabelViewModel(
+                    HtmlContent(
+                        s"""<span class="govuk-caption-xl"><span class="govuk-visually-hidden">${messages("caption.prefix")} </span>${messages("describeTheConditions.caption")}</span>${messages("describeTheConditions.heading")}"""
+                    )
+                ).asPageHeading()
             )
             .withRows(15)
             .withMaxLength(8167)

--- a/app/views/DescribeTheIdenticalGoodsView.scala.html
+++ b/app/views/DescribeTheIdenticalGoodsView.scala.html
@@ -27,6 +27,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -51,8 +52,10 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    @caption(messages("describeTheIdenticalGoods.caption"))
-    @heading(messages("describeTheIdenticalGoods.heading"))
+    @captionedHeading(
+        caption = messages("describeTheIdenticalGoods.caption"),
+        heading = messages("describeTheIdenticalGoods.heading")
+    )
 
     @paraContent
 

--- a/app/views/DescribeTheLegalChallengesView.scala.html
+++ b/app/views/DescribeTheLegalChallengesView.scala.html
@@ -23,8 +23,6 @@
     govukErrorSummary: GovukErrorSummary,
     hmrcCharacterCount: HmrcCharacterCount,
     cancelLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
     paragraph: Paragraph,
     saveButton: SaveButton
 )
@@ -41,12 +39,14 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("describeTheLegalChallenges.caption"))
-
         @hmrcCharacterCount(
             CharacterCountViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("describeTheLegalChallenges.heading")).asPageHeading()
+                label = LabelViewModel(
+                    HtmlContent(
+                        s"""<span class="govuk-caption-xl"><span class="govuk-visually-hidden">${messages("caption.prefix")} </span>${messages("describeTheLegalChallenges.caption")}</span>${messages("describeTheLegalChallenges.heading")}"""
+                    )
+                ).asPageHeading()
             )
             .withRows(15)
             .withMaxLength(8167)

--- a/app/views/DescribeTheRestrictionsView.scala.html
+++ b/app/views/DescribeTheRestrictionsView.scala.html
@@ -23,8 +23,6 @@
     hmrcCharacterCount: HmrcCharacterCount,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
     paragraph: Paragraph,
     saveButton: SaveButton
 )
@@ -41,12 +39,14 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("describeTheRestrictions.caption"))
-
         @hmrcCharacterCount(
             CharacterCountViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("describeTheRestrictions.heading")).asPageHeading()
+                label = LabelViewModel(
+                    HtmlContent(
+                        s"""<span class="govuk-caption-xl"><span class="govuk-visually-hidden">${messages("caption.prefix")} </span>${messages("describeTheRestrictions.caption")}</span>${messages("describeTheRestrictions.heading")}"""
+                    )
+                ).asPageHeading()
             )
             .withRows(15)
             .withMaxLength(8167)

--- a/app/views/DescribeTheSimilarGoodsView.scala.html
+++ b/app/views/DescribeTheSimilarGoodsView.scala.html
@@ -26,6 +26,7 @@
     cancelLink: CancelApplicationLink,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     list: BulletList,
     saveButton: SaveButton
@@ -52,9 +53,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("describeTheSimilarGoods.caption"))
-
-        @heading(messages("describeTheSimilarGoods.heading"))
+        @captionedHeading(
+            caption = messages("describeTheSimilarGoods.caption"),
+            heading = messages("describeTheSimilarGoods.heading")
+        )
 
         @paraContent
 

--- a/app/views/DescriptionOfGoodsView.scala.html
+++ b/app/views/DescriptionOfGoodsView.scala.html
@@ -23,8 +23,6 @@
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
     cancelLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
     saveButton: SaveButton
 )
 
@@ -38,12 +36,14 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("descriptionOfGoods.caption"))
-
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("descriptionOfGoods.heading")).asPageHeading()
+                label = LabelViewModel(
+                    HtmlContent(
+                        s"""<span class="govuk-caption-xl"><span class="govuk-visually-hidden">${messages("caption.prefix")} </span>${messages("descriptionOfGoods.caption")}</span>${messages("descriptionOfGoods.heading")}"""
+                    )
+                ).asPageHeading()
             )
             .withWidth(Full)
             .withHint(Hint(

--- a/app/views/DoYouWantToUploadDocumentsView.scala.html
+++ b/app/views/DoYouWantToUploadDocumentsView.scala.html
@@ -25,6 +25,7 @@
     list: BulletList,
     para: Paragraph,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     subheading: Subheading,
     saveButton: SaveButton,
@@ -40,8 +41,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("doYouWantToUploadDocuments.caption"))
-        @heading(messages("doYouWantToUploadDocuments.heading"))
+        @captionedHeading(
+            caption = messages("doYouWantToUploadDocuments.caption"),
+            heading = messages("doYouWantToUploadDocuments.heading")
+        )
 
         @para(Html(messages("doYouWantToUploadDocuments.para")))
         @list(

--- a/app/views/EORIBeUpToDateView.scala.html
+++ b/app/views/EORIBeUpToDateView.scala.html
@@ -23,6 +23,7 @@
   formHelper: FormWithCSRF,
   caption: Caption,
   heading: Heading,
+  captionedHeading: CaptionedHeading,
   paragraph: Paragraph,
   link: Link,
   bulletList: BulletList,
@@ -53,14 +54,18 @@
         if (Set(OrganisationUser, OrganisationAssistant, Agent).exists(_ == authUserType)) "eoriBeUpToDate.title.org" else "eoriBeUpToDate.title"
     )),
     draftId = Some(draftId)) {
-
-        @caption(messages("eoriBeUpToDate.caption"))
         @if(Set(OrganisationUser, OrganisationAssistant, Agent).exists(_ == authUserType)) {
-            @heading(messages("eoriBeUpToDate.heading.org"))
+            @captionedHeading(
+                caption = messages("eoriBeUpToDate.caption"),
+                heading = messages("eoriBeUpToDate.heading.org")
+            )
             @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.1.org")))
             @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.2.org")))
         } else {
-            @heading(messages("eoriBeUpToDate.heading"))
+            @captionedHeading(
+                caption = messages("eoriBeUpToDate.caption"),
+                heading = messages("eoriBeUpToDate.heading")
+            )
             @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.1")))
             @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.2")))
         }

--- a/app/views/EmployeeCheckRegisteredDetailsView.scala.html
+++ b/app/views/EmployeeCheckRegisteredDetailsView.scala.html
@@ -21,8 +21,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     headingH3: headingH3,
     paragraph: Paragraph,
     subheading: Subheading,
@@ -35,9 +34,15 @@
 
 @headingContent = {
                 @if(registeredDetails.consentToDisclosureOfPersonalData) {
-                    @heading(messages("checkRegisteredDetails.heading.employeeOrg", registeredDetails.EORINo))
+                    @captionedHeading(
+                        caption = messages("checkRegisteredDetails.caption"),
+                        heading = messages("checkRegisteredDetails.heading.employeeOrg", registeredDetails.EORINo)
+                    )
                 } else {
-                    @heading(messages("checkRegisteredDetails.private.heading", registeredDetails.EORINo))
+                    @captionedHeading(
+                        caption = messages("checkRegisteredDetails.caption"),
+                        heading = messages("checkRegisteredDetails.private.heading", registeredDetails.EORINo)
+                    )
                 }
 }
 
@@ -84,7 +89,6 @@
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value")))
         }
 
-        @caption(messages("checkRegisteredDetails.caption"))
         @headingContent
 
         @paraContent

--- a/app/views/EmployeeEORIBeUpToDateView.scala.html
+++ b/app/views/EmployeeEORIBeUpToDateView.scala.html
@@ -23,6 +23,7 @@
   formHelper: FormWithCSRF,
   caption: Caption,
   heading: Heading,
+    captionedHeading: CaptionedHeading,
   paragraph: Paragraph,
   link: Link,
   bulletList: BulletList,
@@ -50,9 +51,10 @@
 
 @layout(pageTitle = titleNoForm(messages("eoriBeUpToDate.title")), draftId = Some(draftId)) {
 
-    @caption(messages("eoriBeUpToDate.caption"))
-
-    @heading(messages("eoriBeUpToDate.heading"))
+    @captionedHeading(
+        caption = messages("eoriBeUpToDate.caption"),
+        heading = messages("eoriBeUpToDate.heading")
+    )
     @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.1")))
     @paragraph(content = Html(messages("eoriBeUpToDate.paragraph.2")))
 

--- a/app/views/ExplainHowPartiesAreRelatedView.scala.html
+++ b/app/views/ExplainHowPartiesAreRelatedView.scala.html
@@ -24,8 +24,7 @@
     govukInput: GovukInput,
     hmrcCharacterCount: HmrcCharacterCount,
     paragraph: Paragraph,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     subheading: Subheading,
     saveButton: SaveButton
@@ -46,9 +45,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("explainHowPartiesAreRelated.caption"))
-
-        @heading(messages("explainHowPartiesAreRelated.heading"))
+        @captionedHeading(
+            caption = messages("explainHowPartiesAreRelated.caption"),
+            heading = messages("explainHowPartiesAreRelated.heading")
+        )
 
         @paraContent
 
@@ -68,4 +68,3 @@
     }
     @cancelLink(draftId)
 }
-

--- a/app/views/ExplainHowYouWillUseMethodSixView.scala.html
+++ b/app/views/ExplainHowYouWillUseMethodSixView.scala.html
@@ -26,6 +26,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -44,8 +45,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("explainHowYouWillUseMethodSix.caption"))
-        @heading(messages("explainHowYouWillUseMethodSix.heading"))
+        @captionedHeading(
+            caption = messages("explainHowYouWillUseMethodSix.caption"),
+            heading = messages("explainHowYouWillUseMethodSix.heading")
+        )
 
         @paraContent
 

--- a/app/views/ExplainReasonComputedValueView.scala.html
+++ b/app/views/ExplainReasonComputedValueView.scala.html
@@ -26,6 +26,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -42,9 +43,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-    @caption(messages("explainReasonComputedValue.caption"))
-
-    @heading(messages("explainReasonComputedValue.heading"))
+    @captionedHeading(
+        caption = messages("explainReasonComputedValue.caption"),
+        heading = messages("explainReasonComputedValue.heading")
+    )
 
     @hmrcCharacterCount(
         CharacterCountViewModel(

--- a/app/views/ExplainWhyYouChoseMethodFourView.scala.html
+++ b/app/views/ExplainWhyYouChoseMethodFourView.scala.html
@@ -27,6 +27,7 @@
     caption: Caption,
     paragraph: Paragraph,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     subheading: Subheading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
@@ -42,9 +43,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-    @caption(messages("explainWhyYouChoseMethodFour.caption"))
-
-    @heading(messages("explainWhyYouChoseMethodFour.heading"))
+    @captionedHeading(
+        caption = messages("explainWhyYouChoseMethodFour.caption"),
+        heading = messages("explainWhyYouChoseMethodFour.heading")
+    )
 
     @paragraph(Html(messages("explainWhyYouChoseMethodFour.paragraph.1")))
 

--- a/app/views/ExplainWhyYouHaveNotSelectedMethodOneToFiveView.scala.html
+++ b/app/views/ExplainWhyYouHaveNotSelectedMethodOneToFiveView.scala.html
@@ -26,6 +26,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -40,9 +41,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("explainWhyYouHaveNotSelectedMethodOneToFive.caption"))
-
-        @heading(messages("explainWhyYouHaveNotSelectedMethodOneToFive.heading"))
+        @captionedHeading(
+            caption = messages("explainWhyYouHaveNotSelectedMethodOneToFive.caption"),
+            heading = messages("explainWhyYouHaveNotSelectedMethodOneToFive.heading")
+        )
 
         @paragraph(Html(messages("explainWhyYouHaveNotSelectedMethodOneToFive.paragraph.1")))
 

--- a/app/views/ExplainWhyYouHaveNotSelectedMethodOneToThreeView.scala.html
+++ b/app/views/ExplainWhyYouHaveNotSelectedMethodOneToThreeView.scala.html
@@ -27,6 +27,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -41,9 +42,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("explainWhyYouHaveNotSelectedMethodOneToThree.caption"))
-
-        @heading(messages("explainWhyYouHaveNotSelectedMethodOneToThree.heading"))
+        @captionedHeading(
+            caption = messages("explainWhyYouHaveNotSelectedMethodOneToThree.caption"),
+            heading = messages("explainWhyYouHaveNotSelectedMethodOneToThree.heading")
+        )
 
         @paragraph(Html(messages("explainWhyYouHaveNotSelectedMethodOneToThree.paragraph.1")))
 

--- a/app/views/HasCommodityCodeView.scala.html
+++ b/app/views/HasCommodityCodeView.scala.html
@@ -22,8 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     link: Link,
     paragraph: Paragraph,
     config: FrontendAppConfig,
@@ -61,8 +60,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("hasCommodityCode.caption"))
-        @heading(messages("hasCommodityCode.heading"))
+        @captionedHeading(
+            caption = messages("hasCommodityCode.caption"),
+            heading = messages("hasCommodityCode.heading")
+        )
         @radiosContent
 
         @govukRadios(

--- a/app/views/HasConfidentialInformationView.scala.html
+++ b/app/views/HasConfidentialInformationView.scala.html
@@ -23,6 +23,7 @@
     govukRadios: GovukRadios,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
     govukInsetText: GovukInsetText,
@@ -50,9 +51,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("hasConfidentialInformation.caption"))
-
-        @heading(messages("hasConfidentialInformation.heading"))
+        @captionedHeading(
+            caption = messages("hasConfidentialInformation.caption"),
+            heading = messages("hasConfidentialInformation.heading")
+        )
 
         @content
 

--- a/app/views/HaveTheGoodsBeenSubjectToLegalChallengesView.scala.html
+++ b/app/views/HaveTheGoodsBeenSubjectToLegalChallengesView.scala.html
@@ -21,8 +21,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
     saveButton: SaveButton,
@@ -46,9 +45,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("haveTheGoodsBeenSubjectToLegalChallenges.caption"))
-
-        @heading(messages("haveTheGoodsBeenSubjectToLegalChallenges.heading"))
+        @captionedHeading(
+            caption = messages("haveTheGoodsBeenSubjectToLegalChallenges.caption"),
+            heading = messages("haveTheGoodsBeenSubjectToLegalChallenges.heading")
+        )
 
         @paraContent
 

--- a/app/views/HaveYouReceivedADecisionView.scala.html
+++ b/app/views/HaveYouReceivedADecisionView.scala.html
@@ -24,8 +24,7 @@ layout: templates.Layout,
 formHelper: FormWithCSRF,
 govukErrorSummary: GovukErrorSummary,
 govukRadios: GovukRadios,
-caption: Caption,
-heading: Heading,
+captionedHeading: CaptionedHeading,
 headingH3: headingH3,
 subheading: Subheading,
 paragraph: Paragraph,
@@ -57,8 +56,10 @@ link: Link
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("caption.goods"))
-        @heading(messages("haveYouReceivedADecision.heading"))
+        @captionedHeading(
+            caption = messages("caption.goods"),
+            heading = messages("haveYouReceivedADecision.heading")
+        )
 
         @paragraph(Html(messages("haveYouReceivedADecision.para.1")))
         @paragraph(Html(messages("haveYouReceivedADecision.para.2")))

--- a/app/views/HaveYouUsedMethodOneForSimilarGoodsInPastView.scala.html
+++ b/app/views/HaveYouUsedMethodOneForSimilarGoodsInPastView.scala.html
@@ -24,6 +24,7 @@
     caption: Caption,
     paragraph: Paragraph,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     bulletList: BulletList,
     govukInsetText: GovukInsetText,
@@ -61,8 +62,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("haveYouUsedMethodOneForSimilarGoodsInPast.caption"))
-        @heading(messages("haveYouUsedMethodOneForSimilarGoodsInPast.heading"))
+        @captionedHeading(
+            caption = messages("haveYouUsedMethodOneForSimilarGoodsInPast.caption"),
+            heading = messages("haveYouUsedMethodOneForSimilarGoodsInPast.heading")
+        )
 
         @radiosContent
 

--- a/app/views/HaveYouUsedMethodOneInPastView.scala.html
+++ b/app/views/HaveYouUsedMethodOneInPastView.scala.html
@@ -24,6 +24,7 @@
     caption: Caption,
     paragraph: Paragraph,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     bulletList: BulletList,
     govukInsetText: GovukInsetText,
@@ -42,8 +43,10 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    @caption(messages("haveYouUsedMethodOneInPast.caption"))
-    @heading(messages("haveYouUsedMethodOneInPast.heading"))
+    @captionedHeading(
+        caption = messages("haveYouUsedMethodOneInPast.caption"),
+        heading = messages("haveYouUsedMethodOneInPast.heading")
+    )
 
     @paragraph(Html(messages("haveYouUsedMethodOneInPast.paragraph.2")))
 

--- a/app/views/ImportGoodsView.scala.html
+++ b/app/views/ImportGoodsView.scala.html
@@ -43,9 +43,13 @@
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
-        @caption(messages("importGoods.caption"))
 
-        @radios(messages("importGoods.heading"), radiosContent, form)
+        @radios(
+            messages("importGoods.heading"),
+            radiosContent,
+            form,
+            caption = Some(messages("importGoods.caption"))
+        )
 
         @saveButton(draftId)
     }

--- a/app/views/ImportingGoodsView.scala.html
+++ b/app/views/ImportingGoodsView.scala.html
@@ -27,6 +27,7 @@
         caption: Caption,
         config: FrontendAppConfig,
         heading: Heading,
+    captionedHeading: CaptionedHeading,
         subheading: Subheading
 )
 
@@ -82,8 +83,10 @@
 
 @layout(pageTitle = titleNoForm(messages("importingGoods.title")), draftId = Some(draftId)) {
 
-    @caption(messages("importingGoods.caption"))
-    @heading(messages("importingGoods.heading"))
+    @captionedHeading(
+        caption = messages("importingGoods.caption"),
+        heading = messages("importingGoods.heading")
+    )
     @subheading(messages("importingGoods.h2"))
 
     @bulletList(

--- a/app/views/InvalidTraderEoriView.scala.html
+++ b/app/views/InvalidTraderEoriView.scala.html
@@ -24,6 +24,7 @@
     govukInput: GovukInput,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
     link: Link
@@ -42,8 +43,10 @@
 
 @layout(pageTitle = titleNoForm(messages("invalidTraderEori.title", eoriNo)), draftId = Some(draftId)) {
 
-    @caption(messages("caption.applicant"))
-    @heading(messages("invalidTraderEori.heading", eoriNo))
+    @captionedHeading(
+        caption = messages("caption.applicant"),
+        heading = messages("invalidTraderEori.heading", eoriNo)
+    )
     @paragraph(content = Html(messages("invalidTraderEori.p1")))
     @paragraph(content = Html(messages("invalidTraderEori.p2")))
     @paragraph(content = Html(messages("traderDetails.common.searchAgain", searchAgainLink)))

--- a/app/views/IsSaleBetweenRelatedPartiesView.scala.html
+++ b/app/views/IsSaleBetweenRelatedPartiesView.scala.html
@@ -21,8 +21,6 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    caption: Caption,
-    heading: Heading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
     saveButton: SaveButton,
@@ -43,9 +41,12 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("isSaleBetweenRelatedParties.caption"))
-
-        @radios(messages("isSaleBetweenRelatedParties.heading"), radiosContent, form)
+        @radios(
+            messages("isSaleBetweenRelatedParties.heading"),
+            radiosContent,
+            form,
+            caption = Some(messages("isSaleBetweenRelatedParties.caption"))
+        )
 
         @saveButton(draftId)
     }

--- a/app/views/IsTheSaleSubjectToConditionsView.scala.html
+++ b/app/views/IsTheSaleSubjectToConditionsView.scala.html
@@ -23,8 +23,7 @@
     govukRadios: GovukRadios,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     paragraph: Paragraph,
     saveButton: SaveButton,
     legend: LegendH2
@@ -40,8 +39,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("isTheSaleSubjectToConditions.caption"))
-        @heading(messages("isTheSaleSubjectToConditions.heading"))
+        @captionedHeading(
+            caption = messages("isTheSaleSubjectToConditions.caption"),
+            heading = messages("isTheSaleSubjectToConditions.heading")
+        )
 
         @paragraph(content = Html(messages("isTheSaleSubjectToConditions.paragraph.1")))
         @bulletList(Seq(

--- a/app/views/IsThereASaleInvolvedView.scala.html
+++ b/app/views/IsThereASaleInvolvedView.scala.html
@@ -21,8 +21,6 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    caption: Caption,
-    heading: Heading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
     saveButton: SaveButton
@@ -39,12 +37,15 @@
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
-        @caption(messages("isThereASaleInvolved.caption"))
 
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("isThereASaleInvolved.heading")).asPageHeading(),
+                legend = LegendViewModel(
+                    HtmlContent(
+                        s"""<span class="govuk-caption-xl"><span class="govuk-visually-hidden">${messages("caption.prefix")} </span>${messages("isThereASaleInvolved.caption")}</span>${messages("isThereASaleInvolved.heading")}"""
+                    )
+                ).asPageHeading(),
                 noText = messages("isThereASaleInvolved.no.text")
             )
             .withHint(Hint(content = HtmlContent(paraContent)))

--- a/app/views/IsThisFileConfidentialView.scala.html
+++ b/app/views/IsThisFileConfidentialView.scala.html
@@ -24,6 +24,7 @@
     govukRadios: GovukRadios,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
     govukButton: GovukButton,
@@ -40,8 +41,10 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    @caption(messages("isThisFileConfidential.caption"))
-    @heading(messages("isThisFileConfidential.heading"))
+    @captionedHeading(
+        caption = messages("isThisFileConfidential.caption"),
+        heading = messages("isThisFileConfidential.heading")
+    )
 
     @subheading(messages("isThisFileConfidential.uploadedFile"))
     @govukInset(InsetText(content = Text(fileName)))

--- a/app/views/ProvideTraderEoriView.scala.html
+++ b/app/views/ProvideTraderEoriView.scala.html
@@ -22,7 +22,6 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    caption: Caption,
     cancelApplicationLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -37,13 +36,13 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("caption.applicant"))
-
         @govukInput(
             InputViewModel(
                 field = form("value"),
                 label = Label(
-                    content = Text(messages("provideTraderEori.heading"))
+                    content = HtmlContent(
+                        s"""<span class="govuk-caption-xl"><span class="govuk-visually-hidden">${messages("caption.prefix")} </span>${messages("caption.applicant")}</span>${messages("provideTraderEori.heading")}"""
+                    )
                 )
                 .asPageHeading()
             )
@@ -56,4 +55,3 @@
 
     @cancelApplicationLink(draftId)
 }
-

--- a/app/views/TellUsAboutYourRulingView.scala.html
+++ b/app/views/TellUsAboutYourRulingView.scala.html
@@ -25,8 +25,7 @@
     hmrcCharacterCount: HmrcCharacterCount,
     list: BulletList,
     paragraph: Paragraph,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -54,9 +53,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("caption.goods"))
-
-        @heading(messages("tellUsAboutYourRuling.heading"))
+        @captionedHeading(
+            caption = messages("caption.goods"),
+            heading = messages("tellUsAboutYourRuling.heading")
+        )
 
         @content
 

--- a/app/views/UploadAnotherSupportingDocumentView.scala.html
+++ b/app/views/UploadAnotherSupportingDocumentView.scala.html
@@ -24,6 +24,7 @@
     govukRadios: GovukRadios,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     subheading: Subheading,
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
@@ -86,9 +87,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
     
-        @caption(messages("uploadAnotherSupportingDocument.caption"))
-
-        @heading(pageHeading)
+        @captionedHeading(
+            caption = messages("uploadAnotherSupportingDocument.caption"),
+            heading = pageHeading
+        )
 
         @if(letterOfAuthorityFileName.isDefined) {
             @if(numOfDocs == 3) {

--- a/app/views/UploadInProgressView.scala.html
+++ b/app/views/UploadInProgressView.scala.html
@@ -20,6 +20,7 @@
         layout: templates.Layout,
         govukButton: GovukButton,
         heading: Heading,
+    captionedHeading: CaptionedHeading,
         caption: Caption,
         formHelper: FormWithCSRF,
         cancelLink: CancelApplicationLink
@@ -31,8 +32,10 @@
 
     @formHelper(action = routes.UploadInProgressController.checkProgress(draftId, key, isLetterOfAuthority)) {
 
-        @caption(messages("caption.goods"))
-        @heading(messages("uploadInProgress.heading"))
+        @captionedHeading(
+            caption = messages("caption.goods"),
+            heading = messages("uploadInProgress.heading")
+        )
 
         <p class="govuk-body">@messages("uploadInProgress.p1")</p>
 

--- a/app/views/UploadLetterOfAuthorityView.scala.html
+++ b/app/views/UploadLetterOfAuthorityView.scala.html
@@ -25,6 +25,7 @@
         govukFileUpload: GovukFileUpload,
         caption: Caption,
         heading: Heading,
+    captionedHeading: CaptionedHeading,
         cancelApplicationLink: CancelApplicationLink,
         govukInsetText: GovukInsetText,
         paragraph: Paragraph,
@@ -83,8 +84,10 @@
     @govukErrorSummary(ErrorSummaryViewModel.withoutForm(Map("file-input" -> messages(errorMessage))))
   }
 
-  @caption(messages("uploadLetterOfAuthority.caption"))
-  @heading(messages("uploadLetterOfAuthority.heading"))
+  @captionedHeading(
+      caption = messages("uploadLetterOfAuthority.caption"),
+      heading = messages("uploadLetterOfAuthority.heading")
+  )
 
   @govukInsetText(InsetText(
     content = Text(messages("uploadLetterOfAuthority.insetPara"))

--- a/app/views/UploadSupportingDocumentsView.scala.html
+++ b/app/views/UploadSupportingDocumentsView.scala.html
@@ -25,6 +25,7 @@
         govukFileUpload: GovukFileUpload,
         caption: Caption,
         heading: Heading,
+    captionedHeading: CaptionedHeading,
         cancelApplicationLink: CancelApplicationLink,
         paragraph: Paragraph,
         list: BulletList,
@@ -73,8 +74,10 @@
     @govukErrorSummary(ErrorSummaryViewModel.withoutForm(Map("file-input" -> messages(errorMessage))))
   }
 
-  @caption(messages("uploadSupportingDocuments.caption"))
-  @heading(messages("uploadSupportingDocuments.heading"))
+  @captionedHeading(
+      caption = messages("uploadSupportingDocuments.caption"),
+      heading = messages("uploadSupportingDocuments.heading")
+  )
 
   @paragraph(Html(messages("uploadSupportingDocuments.details.paragraph", maxSupportingDocuments)))
 

--- a/app/views/ValuationMethodView.scala.html
+++ b/app/views/ValuationMethodView.scala.html
@@ -24,8 +24,6 @@
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
     cancelApplicationLink: CancelApplicationLink,
-    caption: Caption,
-    heading: Heading,
     subheading: Subheading,
     paragraph: Paragraph,
     link: Link,
@@ -35,14 +33,19 @@
 
 @(form: Form[?], mode: Mode, draftId: DraftId)(implicit request: RequestHeader, messages: Messages)
 
-@legend = {<h1 class="govuk-heading-xl">@messages("valuationMethod.heading")</h1>}
+@legend = {
+    <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">
+            <span class="govuk-visually-hidden">@messages("caption.prefix") </span>@messages("valuationMethod.caption")
+        </span>
+        @messages("valuationMethod.heading")
+    </h1>
+}
 
 @layout(pageTitle = title(form, messages("valuationMethod.title")), draftId = Some(draftId)) {
 
 
     @formHelper(action = routes.ValuationMethodController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
-
-        @caption(messages("valuationMethod.caption"))
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))

--- a/app/views/VerifyLetterOfAuthorityView.scala.html
+++ b/app/views/VerifyLetterOfAuthorityView.scala.html
@@ -25,6 +25,7 @@
     link: Link,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     subheading: Subheading,
     cancelApplicationLink: CancelApplicationLink,
     paragraph: Paragraph,
@@ -41,9 +42,10 @@
 
     @formHelper(action = routes.VerifyLetterOfAuthorityController.onSubmit(mode, draftId), Symbol("autoComplete") -> "off") {
 
-        @caption(messages("verifyLetterOfAuthority.caption"))
-
-        @heading(pageHeading)
+        @captionedHeading(
+            caption = messages("verifyLetterOfAuthority.caption"),
+            heading = pageHeading
+        )
 
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">

--- a/app/views/VerifyPrivateTraderDetailView.scala.html
+++ b/app/views/VerifyPrivateTraderDetailView.scala.html
@@ -26,6 +26,7 @@
     govukRadios: GovukRadios,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     subheading: Subheading,
     paragraph: Paragraph,
     cancelApplicationLink: CancelApplicationLink,
@@ -61,8 +62,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-        @caption(messages("caption.applicant"))
-        @heading(messages("traderDetails.private.heading", details.EORINo))
+        @captionedHeading(
+            caption = messages("caption.applicant"),
+            heading = messages("traderDetails.private.heading", details.EORINo)
+        )
 
         @paraContent
 

--- a/app/views/VerifyPublicTraderDetailView.scala.html
+++ b/app/views/VerifyPublicTraderDetailView.scala.html
@@ -26,6 +26,7 @@
     govukRadios: GovukRadios,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     headingH3: headingH3,
     paragraph: Paragraph,
     subheading: Subheading,
@@ -39,9 +40,15 @@
 
 @headingContent = {
                 @if(registeredDetails.consentToDisclosureOfPersonalData) {
-                    @heading(messages("checkRegisteredDetails.heading.agentTrader", registeredDetails.EORINo))
+                    @captionedHeading(
+                        caption = messages("checkRegisteredDetails.caption"),
+                        heading = messages("checkRegisteredDetails.heading.agentTrader", registeredDetails.EORINo)
+                    )
                 } else {
-                    @heading(messages("checkRegisteredDetails.private.heading", registeredDetails.EORINo))
+                    @captionedHeading(
+                        caption = messages("checkRegisteredDetails.caption"),
+                        heading = messages("checkRegisteredDetails.private.heading", registeredDetails.EORINo)
+                    )
                 }
 }
 
@@ -87,7 +94,6 @@
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value")))
         }
 
-        @caption(messages("checkRegisteredDetails.caption"))
         @headingContent
 
         @paraContent
@@ -120,4 +126,3 @@
 
     @cancelApplicationLink(draftId)
 }
-

--- a/app/views/WhatIsYourRoleAsImporterView.scala.html
+++ b/app/views/WhatIsYourRoleAsImporterView.scala.html
@@ -22,8 +22,7 @@
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    caption: Caption,
-    heading: Heading,
+    captionedHeading: CaptionedHeading,
     para: Paragraph,
     button: SubmitButton,
     config: FrontendAppConfig,
@@ -50,9 +49,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
         }
 
-        @caption(messages("caption.applicant"))
-
-        @heading(messages("whatIsYourRoleAsImporter.heading"))
+        @captionedHeading(
+            caption = messages("caption.applicant"),
+            heading = messages("whatIsYourRoleAsImporter.heading")
+        )
 
         @content
 

--- a/app/views/WhyComputedValueView.scala.html
+++ b/app/views/WhyComputedValueView.scala.html
@@ -26,6 +26,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     bulletList: BulletList,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
@@ -41,9 +42,10 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
-    @caption(messages("whyComputedValue.caption"))
-
-    @heading(messages("whyComputedValue.heading"))
+    @captionedHeading(
+        caption = messages("whyComputedValue.caption"),
+        heading = messages("whyComputedValue.heading")
+    )
 
     @paragraph(Html(messages("whyComputedValue.paragraph.1")))
 

--- a/app/views/WhyIdenticalGoodsView.scala.html
+++ b/app/views/WhyIdenticalGoodsView.scala.html
@@ -27,6 +27,7 @@
     bulletList: BulletList,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     cancelLink: CancelApplicationLink,
     saveButton: SaveButton
 )
@@ -43,9 +44,10 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    @caption(messages("whyIdenticalGoods.caption"))
-
-    @heading(messages("whyIdenticalGoods.heading"))
+    @captionedHeading(
+        caption = messages("whyIdenticalGoods.caption"),
+        heading = messages("whyIdenticalGoods.heading")
+    )
 
     @paraContent
 

--- a/app/views/WhyTransactionValueOfSimilarGoodsView.scala.html
+++ b/app/views/WhyTransactionValueOfSimilarGoodsView.scala.html
@@ -26,6 +26,7 @@
     paragraph: Paragraph,
     caption: Caption,
     heading: Heading,
+    captionedHeading: CaptionedHeading,
     bulletList: BulletList,
     saveButton: SaveButton
 )
@@ -40,9 +41,10 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    @caption(messages("whyTransactionValueOfSimilarGoods.caption"))
-
-    @heading(messages("whyTransactionValueOfSimilarGoods.heading"))
+    @captionedHeading(
+        caption = messages("whyTransactionValueOfSimilarGoods.caption"),
+        heading = messages("whyTransactionValueOfSimilarGoods.heading")
+    )
 
     @paragraph(Html(messages("whyTransactionValueOfSimilarGoods.paragraph.1")))
 

--- a/app/views/components/CaptionedHeading.scala.html
+++ b/app/views/components/CaptionedHeading.scala.html
@@ -1,0 +1,26 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(caption: String, heading: String, headingSize: String = "xl", captionSize: String = "xl", captionPrefix: String = "caption.prefix")(implicit messages: Messages)
+
+<h1 class="govuk-heading-@headingSize">
+  <span class="govuk-caption-@captionSize">
+    <span class="govuk-visually-hidden">@messages(captionPrefix) </span>@caption
+  </span>
+  @heading
+</h1>

--- a/app/views/components/YesNoRadios.scala.html
+++ b/app/views/components/YesNoRadios.scala.html
@@ -16,7 +16,7 @@
 
 @this()
 
-@(heading: String, content: Html, form: Form[?])(implicit messages: Messages)
+@(heading: String, content: Html, form: Form[?], caption: Option[String] = None, captionPrefix: String = "caption.prefix")(implicit messages: Messages)
 
 @valueToCheck(valueToCheck: String) = @{
  if (form("value").value.isDefined && form("value").value.get == valueToCheck) {
@@ -64,7 +64,14 @@ if(form.errors.nonEmpty) {
  <fieldset class="govuk-fieldset govuk-!-margin-bottom-6" aria-describedby="@ariaDescribedBy">
 
  <legend class="govuk-fieldset__legend  govuk-fieldset__legend--xl">
-  <h1 class="govuk-fieldset__heading">@heading</h1>
+  <h1 class="govuk-fieldset__heading">
+   @caption.map { captionText =>
+    <span class="govuk-caption-xl">
+     <span class="govuk-visually-hidden">@messages(captionPrefix) </span>@captionText
+    </span>
+   }
+   @heading
+  </h1>
  </legend>
 
  @content

--- a/test/views/ViewSpecBase.scala
+++ b/test/views/ViewSpecBase.scala
@@ -71,7 +71,7 @@ trait ViewSpecBase extends SpecBase with GuiceOneAppPerSuite {
         headers.first.ownText().replaceAll("\u00a0", " ") mustBe messages(expectedMessageKey, args*)
           .replaceAll("&nbsp;", " ")
       case 1                                    =>
-        headers.select("label").text().replaceAll("\u00a0", " ") mustBe messages(expectedMessageKey, args*)
+        headers.select("label").first.ownText().replaceAll("\u00a0", " ") mustBe messages(expectedMessageKey, args*)
           .replaceAll("&nbsp;", " ")
       case _                                    => throw new RuntimeException(s"Pages should only have (at most) one h1 element. Found ${headers.size}")
     }


### PR DESCRIPTION
Changes - 

- added a new `CaptionedHeading` component for simple page headings
- updated pages that rendered captions and headings separately to use it
- updated helper-driven pages so captions sit inside the page-heading legend
- updated ViewSpecBase.scala




## Result